### PR TITLE
fix(EgovBoard): 블로그 게시판 목록의 총 건수 조인 조건이 자기 자신을 비교하는 문제 수정

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/bls/service/impl/EgovBbsMasterServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/bls/service/impl/EgovBbsMasterServiceImpl.java
@@ -86,7 +86,7 @@ public class EgovBbsMasterServiceImpl extends EgovAbstractServiceImpl implements
                         .select(bbsMaster.count())
                         .from(bbsMaster)
                         .leftJoin(masterOptn)
-                        .on(bbsMaster.bbsId.eq(bbsMaster.bbsId))
+                        .on(bbsMaster.bbsId.eq(masterOptn.bbsId))
                         .leftJoin(tmplatInfo)
                         .on(bbsMaster.tmplatId.eq(tmplatInfo.tmplatId))
                         .leftJoin(userMaster)


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBbsMasterServiceImpl.list()`(cop/bls)는 목록과 총 건수를 각각 다른 쿼리로 가져옵니다. 목록은 `bbsMasterListQuery()` 헬퍼를 쓰고, 총 건수는 같은 조인을 손으로 다시 적었는데 그 과정에서 `masterOptn.bbsId`를 써야 할 자리에 `bbsMaster.bbsId`가 들어갔습니다.

```java
count   .on(bbsMaster.bbsId.eq(bbsMaster.bbsId))    // 항상 참
helper  .on(bbsMaster.bbsId.eq(masterOptn.bbsId))   // 같은 파일, 정상
```

조건이 항상 참이라 LEFT JOIN이 `COMTNBBSMASTEROPTN` 전체 행과 곱연산이 되고, count가 실제 게시판 수의 (옵션 테이블 행 수)배로 부풀어 오릅니다.

Hibernate가 실제로 내보내는 SQL입니다.

```sql
select count(bm1_0.bbs_id)
from comtnbbsmaster bm1_0
left join comtnbbsmasteroptn bmo1_0
    on bm1_0.bbs_id=bm1_0.bbs_id      -- 자기 자신과 비교
...
where bm1_0.blog_id=?
```

형제 모듈은 count 경로에서도 정상 조인을 씁니다.

| 위치 | 조인 조건 |
|---|---|
| `cop/bls` count (수정 전) | `bbsMaster.bbsId.eq(bbsMaster.bbsId)` |
| `cop/bls` helper | `bbsMaster.bbsId.eq(masterOptn.bbsId)` |
| `cop/bbs:98` count | `bbsMaster.bbsId.eq(bbsMasterOptn.bbsId)` |
| `cop/cmy:99` count | `bbsMaster.bbsId.eq(bbsMasterOptn.bbsId)` |

저장소 전체에서 좌우가 같은 `eq` 비교는 이 한 줄뿐입니다.

```
$ grep -rnP '(\w+)\.(\w+)\.eq\(\1\.\2\)' --include="*.java" .
EgovBoard/src/main/java/egovframework/com/cop/bls/service/impl/EgovBbsMasterServiceImpl.java:89
```

AS-IS / TO-BE

```diff
-                        .on(bbsMaster.bbsId.eq(bbsMaster.bbsId))
+                        .on(bbsMaster.bbsId.eq(masterOptn.bbsId))
```

### 영향 범위

목록에 보이는 내용은 정상 조인을 쓰는 헬퍼가 가져오므로 맞고, **총 건수와 페이지 수만** 틀립니다.

한 가지 덧붙이면, 결과가 한 페이지에 다 들어가는 경우에는 `PageImpl`이 `total`을 `offset + content.size()`로 덮어써서 증상이 가려집니다. 여러 페이지가 될 때만 드러납니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

이 모듈에는 테스트 소스가 없어 임시 하네스로 로컬에서만 확인하고 되돌렸습니다(H2 + `@DataJpaTest`로 실제 `list()`를 호출). 게시판 12건·옵션행 3건·페이지당 10건으로 시드했습니다.

수정 전

```
>>> 시드      bbsMaster=12  masterOptn=3
>>> 직접대조  자기참조조인=36  정상조인=12
>>> list()   totalElements=36  content=10
```

수정 후

```
>>> list()   totalElements=12  content=10
```

모듈 빌드는 CI와 같은 명령으로 확인했습니다.

```
$ mvn -B -ntp -f EgovBoard/pom.xml package -DskipTests
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

서비스 계층 쿼리 수정이라 브라우저와 무관합니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 첨부하지 않았습니다.
