### PR TITLE
fix(mobile-id): Base64Util 인코딩/디코딩 charset UTF-8 고정 — 기본 charset 의존 한글 깨짐 방지

### DIFF
--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/util/Base64Util.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/util/Base64Util.java
@@ -1,5 +1,6 @@
 package egovframework.com.mip.mva.sp.comm.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
@@ -27,7 +28,7 @@ public class Base64Util {
 	 * @return Base64 String
 	 */
 	public static String encode(String text) {
-		return Base64.getUrlEncoder().encodeToString(text.getBytes());
+		return Base64.getUrlEncoder().encodeToString(text.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -49,7 +50,7 @@ public class Base64Util {
 	 * @return String
 	 */
 	public static String decode(String text) {
-		return new String(Base64.getUrlDecoder().decode(text));
+		return new String(Base64.getUrlDecoder().decode(text), StandardCharsets.UTF_8);
 	}
 
 	/**

--- a/EgovMobileId/src/test/java/egovframework/com/mip/mva/sp/comm/util/Base64UtilTest.java
+++ b/EgovMobileId/src/test/java/egovframework/com/mip/mva/sp/comm/util/Base64UtilTest.java
@@ -1,0 +1,34 @@
+package egovframework.com.mip.mva.sp.comm.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Base64Util 이 JVM 기본 charset 과 무관하게 UTF-8 로 인코딩/디코딩하는지 검증한다.
+ *
+ * <p>수정 전에는 {@code text.getBytes()} 와 {@code new String(byte[])} 가 기본 charset 에 의존해,
+ * 서버 기본 charset 이 UTF-8 이 아니면(예: US-ASCII·EUC-KR·MS949) 한글이 깨졌다(CWE-176).
+ * 이 테스트는 UTF-8 계약을 고정하며, 기본 charset 이 UTF-8 이 아닌 JVM 에서 수정 전 코드로 실행하면
+ * 실패한다. (로컬에서 {@code -Dfile.encoding=US-ASCII} 로 판별 확인)</p>
+ */
+class Base64UtilTest {
+
+    @Test
+    void encode_한글을_UTF8_URL_Base64로_고정한다() {
+        // "가"(U+AC00) = UTF-8 바이트 EA B0 80 → URL-safe Base64 "6rCA".
+        // 기본 charset 이 US-ASCII 면 '가'가 '?'(0x3F)로 치환돼 다른 값이 된다.
+        assertEquals("6rCA", Base64Util.encode("가"));
+    }
+
+    @Test
+    void decode_UTF8_Base64를_한글로_복원한다() {
+        assertEquals("가", Base64Util.decode("6rCA"));
+    }
+
+    @Test
+    void encodeDecode_한글영문기호_왕복이_보존된다() {
+        String original = "홍길동-Gil.Dong_2026!";
+        assertEquals(original, Base64Util.decode(Base64Util.encode(original)));
+    }
+}


### PR DESCRIPTION
## 문제

Base64Util.encode(String) 는 text.getBytes() 로, decode(String) 는 new String(byte[]) 로 문자열↔바이트 변환을 합니다. 두 호출 모두 charset 을 지정하지 않아 JVM 기본 charset 에 의존합니다.

서버 기본 charset 이 UTF-8 이 아니면(예: US-ASCII·EUC-KR·MS949 등 일부 국내 서버 환경) 한글이 깨집니다. 기본 charset 이 US-ASCII 인 경우 encode("가") 는 '가'가 '?'(0x3F)로 치환돼 "6rCA" 가 아니라 "Pw==" 가 되고, 왕복(encode→decode) 시 원문이 유실됩니다. 모바일 신분증(운전면허증) 서비스가 한글 이름·CI 등을 Base64 로 다루므로 데이터 무결성·상호운용 문제로 이어질 수 있습니다(CWE-176, Improper Handling of Unicode Encoding).

## 수정

encode/decode 의 문자열↔바이트 변환에 StandardCharsets.UTF_8 을 명시해 기본 charset 과 무관하게 UTF-8 로 동작하도록 했습니다. byte[] 를 직접 다루는 encode(byte[])·decodeToByte 는 charset 과 무관하므로 변경하지 않았습니다. (+3/−2)

## 검증

- Base64UtilTest 추가: encode("가")=="6rCA", decode("6rCA")=="가", 한글·영문·기호 혼합 왕복 보존을 검증(UTF-8 계약 고정).
- 독립 하네스로 재현: 기본 charset 이 UTF-8 이면 수정 전/후 동일하지만, -Dfile.encoding=US-ASCII 로 실행하면 수정 전 encode("가")="Pw==" 로 깨지고 왕복이 유실됨을, 수정 후에는 "6rCA"·왕복 보존됨을 확인.
- 위 테스트를 -Dfile.encoding=US-ASCII 로 실행: 수정 전 3건 실패 → 수정 후 3건 통과(TDD 토글).

참고: 이 환경에선 EgovMobileId 가 의존하는 상용 DID SDK(jar) 문제로 Maven 전체 빌드가 불가해, 의존성이 없는 Base64Util 을 JUnit Platform 런처로 격리 실행해 검증했습니다.