### PR TITLE
fix: VerifyManager debug 로그에서 민감정보 원문 출력 제거 (CWE-532)

### DIFF
--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/util/VerifyManager.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/util/VerifyManager.java
@@ -299,7 +299,7 @@ public class VerifyManager implements InitializingBean {
 
 			String spProfileJson = VerifyApi.makeSpProfile(spProfileParam);
 
-			LOGGER.debug("spProfileJson : {}", spProfileJson);
+			LOGGER.debug("spProfileJson created (content omitted from log)");
 
 			resultProfile = new ResultProfile();
 
@@ -342,7 +342,7 @@ public class VerifyManager implements InitializingBean {
 
 			vcResult = VerifyApi.verify2(vcVerifyProfileParam, false);
 
-			LOGGER.debug("vcResult : {}", vcResult.toJson());
+			LOGGER.debug("vcResult received (content omitted from log)");
 		} catch (BlockChainException e) {
 			throw new SpException(MipErrorEnum.SP_SDK_ERROR, null, e.getErrorMsg());
 		} catch (HttpException e) {
@@ -374,7 +374,7 @@ public class VerifyManager implements InitializingBean {
 
 			vcResult = VerifyApi.checkUserProof(vcVerifyProfileParam, false);
 
-			LOGGER.debug("vcResult : {}", vcResult.toJson());
+			LOGGER.debug("vcResult received (content omitted from log)");
 		} catch (BlockChainException e) {
 			throw new SpException(MipErrorEnum.SP_SDK_ERROR, null, e.getErrorMsg());
 		} catch (HttpException e) {
@@ -454,7 +454,7 @@ public class VerifyManager implements InitializingBean {
 
 			String zkpProfileJson = VerifyApi.makeZkpProfile(spProfileParam);
 
-			LOGGER.debug("zkpProfileJson : {}", zkpProfileJson);
+			LOGGER.debug("zkpProfileJson created (content omitted from log)");
 
 			resultProfile = new ResultProfile();
 
@@ -491,7 +491,7 @@ public class VerifyManager implements InitializingBean {
 
 			String data = new String(vpDataByte);
 
-			LOGGER.debug("data : {}", data);
+			LOGGER.debug("proof data decrypted (content omitted from log)");
 
 			Proof proof = ConfigBean.gson.fromJson(data, Proof.class);
 
@@ -521,7 +521,7 @@ public class VerifyManager implements InitializingBean {
 			SDKResponse sDKResponse = new ZKPApi().verifyProof(iWApiBaseData, proof, proofRequest, proofVerifyParams,
 					verifierNonce);
 
-			LOGGER.debug("sDKResponse : {}", sDKResponse.toJson());
+			LOGGER.debug("sDKResponse received (content omitted from log)");
 
 			resultJson = new ResultJson();
 
@@ -684,7 +684,7 @@ public class VerifyManager implements InitializingBean {
 
 			SDKResponse response = new ZKPApi().createProofRequest(null, attributes, predicates, nonce);
 
-			LOGGER.debug("response : {}", response.toJson());
+			LOGGER.debug("proofRequest response received (content omitted from log)");
 
 			proofRequest = (ProofRequest) response.getResultData();
 			// proofRequest 생성 End
@@ -810,7 +810,7 @@ public class VerifyManager implements InitializingBean {
 
 			vpData = new String(decVp);
 
-			LOGGER.debug("vpData : {}", vpData);
+			LOGGER.debug("vpData decrypted (content omitted from log)");
 		} catch (IWException e) {
 			throw new SpException(MipErrorEnum.SP_SDK_ERROR, null, e.getErrorMsg());
 		} catch (Exception e) {
@@ -857,7 +857,7 @@ public class VerifyManager implements InitializingBean {
 			if (!ObjectUtils.isEmpty(vpNonce) && vpNonce.length() > ciLength) {
 				String info = new String(HexUtils.toBytes(vpNonce.substring(ciLength)));
 
-				LOGGER.debug("info : {}", info);
+				LOGGER.debug("privacy info parsed (content omitted from log)");
 
 				String ci = "";
 
@@ -892,7 +892,7 @@ public class VerifyManager implements InitializingBean {
 				}
 			}
 
-			LOGGER.debug("vcResult : {}", vcResult.toJson());
+			LOGGER.debug("vcResult received (content omitted from log)");
 		} catch (Exception e) {
 			throw new SpException(MipErrorEnum.UNKNOWN_ERROR, null, e.getMessage());
 		}
@@ -912,7 +912,7 @@ public class VerifyManager implements InitializingBean {
 		String encData;
 
 		try {
-			LOGGER.debug("data : {}", data);
+			LOGGER.debug("plain data received (content omitted from log)");
 
 			EosDataApi eosDataApi = new EosDataApi();
 
@@ -927,7 +927,7 @@ public class VerifyManager implements InitializingBean {
 
 			encData = Base64Util.encode(encByteData);
 
-			LOGGER.debug("encData : {}", encData);
+			LOGGER.debug("encData created (content omitted from log)");
 		} catch (BlockChainException | IWException e) {
 			throw new SpException(MipErrorEnum.SP_NETWORK_ERROR, null, e.getErrorMsg());
 		} catch (Exception e) {
@@ -948,14 +948,14 @@ public class VerifyManager implements InitializingBean {
 		String decData;
 
 		try {
-			LOGGER.debug("data : {}", data);
+			LOGGER.debug("encrypted data received (content omitted from log)");
 
 			byte[] encByteData = keyManager.rsaDecrypt(didWalletFile.getEncryptKeyId(), egovframework.com.mip.mva.sp.comm.util.Base64Util.decodeToByte(data),
 					AESType.AES256);
 
 			decData = new String(encByteData);
 
-			LOGGER.debug("decData : {}", decData);
+			LOGGER.debug("decData decrypted (content omitted from log)");
 		} catch (IWException e) {
 			throw new SpException(MipErrorEnum.UNKNOWN_ERROR, null, e.getErrorMsg());
 		} catch (Exception e) {


### PR DESCRIPTION
## 문제

`VerifyManager`(EgovMobileId, 모바일 신분증 검증)가 검증 과정의 민감 데이터를 DEBUG 로그로 원문 출력합니다 (CWE-532, Insertion of Sensitive Information into Log File).

- `getPrivacy()`: VP nonce 뒤에 실린 **CI(연계정보)·전화번호**를 디코딩한 `info` 문자열을 그대로 출력 — 바로 아래 코드에서 `ci` / `telno`로 분리되는 값입니다.
- `getVPData()`: **복호화된 VP 원문**(`vpData`) — 신분증 개인정보가 담긴 Verifiable Presentation 평문.
- `rsaEncrypt()` / `rsaDecrypt()`: 암호화 이전 **평문**(`data`)과 **복호화 평문**(`decData`).
- `verify()` / `checkUserProof()` / `getPrivacy()`: `vcResult.toJson()` — 검증 결과(자격증명 내용 포함) 전체.
- profile / proof / SDK 응답 JSON 원문 등 총 **14곳**.

이 모듈의 기본 설정 `src/main/resources/application.yml`이 `logging.level.egovframework.com: debug`라서, **기본 구성 그대로 위 로그가 활성화**됩니다 — 별도 설정 없이 운영 로그 파일에 신원 PII가 축적됩니다.

## 변경 (±14줄, 로그 문장만)

- 민감 내용 출력 14곳: 흐름 추적용 메시지는 남기고 내용만 제외
  - 예) `LOGGER.debug("vpData : {}", vpData);` → `LOGGER.debug("vpData decrypted (content omitted from log)");`
- 운영 로그 7곳은 유지: keyManager 콜백 마커·errCode, `attrList`/`predList`(서비스 설정의 요청 속성명 목록), `encryptType`/`keyType` 메타데이터.
- 로직·제어 흐름·import 변경 없음. 제거된 인자는 모두 부수효과 없는 순수 표현식(변수 참조, `toJson()` 직렬화)입니다.

## 검증 및 한계

EgovMobileId 모듈은 OmniOne DID SDK 의존성 문제로 현재 저장소 빌드 구성에서 제외되어 있어, 컴파일·테스트 기반 검증이 불가했습니다. 대신 아래의 기계 검증으로 한정했습니다.

- diff 범위: 정확히 14줄 −/+, 전부 `LOGGER.debug(...)` 문장(스크립트 검사).
- 구문: 수정 전/후 모두 Java 파서(javalang)로 정상 파싱, 클래스·메서드 구조 동일(메서드 14개).
- 컴파일 안전성(구성적): 문자열 리터럴 변경과 두 번째 인자 제거뿐, 새 심볼 도입 없음.

실행 환경(SDK 구성 가능)에서의 동작 확인을 부탁드립니다.

## 참고

- `MipController` 등 HTTP 경계의 `LOGGER.debug("data : {}", data)`(암호화 envelope 원문)도 정비 후보입니다 — 리뷰 범위를 줄이기 위해 이 PR에서는 제외했고, 원하시면 후속 PR로 제안하겠습니다.
- 정책상 원문 로그가 필요하면 설정 플래그로 게이트하는 옵트인 방식으로도 조정 가능합니다.