### PR TITLE
fix(EgovLogin): 로그인 시 암호화된 비밀번호를 debug 로그로 남기지 않도록 수정 + 회귀 테스트 (CWE-532)

### DIFF
--- a/EgovLogin/src/main/java/egovframework/com/uat/uia/service/impl/EgovLoginManageServiceImpl.java
+++ b/EgovLogin/src/main/java/egovframework/com/uat/uia/service/impl/EgovLoginManageServiceImpl.java
@@ -39,7 +39,8 @@ public class EgovLoginManageServiceImpl extends EgovAbstractServiceImpl implemen
         String userId = loginVO.getUserId();
         String userSe = loginVO.getUserSe();
         String encPassword = encryptPassword(loginVO.getUserPw(), loginVO.getUserId());
-        log.debug("userId = {}, userSe = {}, encPassword = {}", userId, userSe, encPassword);
+        // encPassword(암호화된 비밀번호)는 로그로 남기지 않는다 (CWE-532).
+        log.debug("userId = {}, userSe = {}", userId, userSe);
 
         QGnrlMber gnrlMber = QGnrlMber.gnrlMber;
         QEntrprsMber entrprsMber = QEntrprsMber.entrprsMber;

--- a/EgovLogin/src/test/java/egovframework/com/uat/uia/service/impl/EgovLoginManageServiceLogTest.java
+++ b/EgovLogin/src/test/java/egovframework/com/uat/uia/service/impl/EgovLoginManageServiceLogTest.java
@@ -1,0 +1,104 @@
+package egovframework.com.uat.uia.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import egovframework.com.uat.uia.service.LoginVO;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+/**
+ * egovframework.com.uat.uia.service.impl.EgovLoginManageServiceLogTest
+ * <p>
+ * Verifies that actionLogin does not expose the encrypted password to the logs (CWE-532).
+ * <p>
+ * encPassword is Base64(SHA-256(userId)(userPw)) -- the stored credential hash used to look
+ * up the member. Logging it means every login (when DEBUG is enabled) writes a
+ * password-derived hash to the log file, enabling offline dictionary attacks against it.
+ * No log event may contain that value.
+ *
+ * @author EricSeokgon
+ * @version 1.0
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovLoginManageServiceLogTest {
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    private EgovLoginManageServiceImpl service;
+
+    private Logger logger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        logger = (Logger) LoggerFactory.getLogger(EgovLoginManageServiceImpl.class);
+        logger.setLevel(Level.DEBUG); // ensure DEBUG events are emitted
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    private LoginVO loginVO(String userId, String userPw, String userSe) {
+        LoginVO vo = new LoginVO();
+        vo.setUserId(userId);
+        vo.setUserPw(userPw);
+        vo.setUserSe(userSe);
+        return vo;
+    }
+
+    @Test
+    @DisplayName("actionLogin must not log the encrypted password (CWE-532)")
+    void actionLogin_doesNotLogEncryptedPassword() {
+        // given
+        String userId = "tester";
+        String userPw = "S3cr3t!Passw0rd";
+        // the exact value the production code computes and would log
+        String encPassword = ReflectionTestUtils.invokeMethod(service, "encryptPassword", userPw, userId);
+
+        assertThat(encPassword)
+                .as("precondition: encryptPassword should produce a non-trivial hash")
+                .isNotBlank()
+                .hasSizeGreaterThan(10);
+
+        // when: invoke the login flow. Downstream QueryDSL access fails fast (mock queryFactory),
+        // but the debug log at the top of actionLogin has already fired by then.
+        try {
+            service.actionLogin(loginVO(userId, userPw, "GNR"));
+        } catch (Exception ignored) {
+            // expected: NPE from the unstubbed query chain, after the log statement under test
+        }
+
+        // then
+        boolean leaked = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .anyMatch(msg -> msg.contains(encPassword));
+
+        assertThat(leaked)
+                .as("encrypted password must not appear in logs (CWE-532). Captured logs: %s",
+                        appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList())
+                .isFalse();
+    }
+}


### PR DESCRIPTION
## 문제 (CWE-532)

`EgovLoginManageServiceImpl.actionLogin()`이 로그인마다 **암호화된 비밀번호를 DEBUG 로그로 원문 출력**합니다.

```java
String encPassword = encryptPassword(loginVO.getUserPw(), loginVO.getUserId());
log.debug("userId = {}, userSe = {}, encPassword = {}", userId, userSe, encPassword);
```

`encPassword`는 `Base64(SHA-256(userId)(userPw))` — 회원 조회·인증에 쓰이는 **저장 자격증명 해시**입니다. DEBUG 로깅이 켜진 환경에서는 모든 로그인 시 비밀번호 파생 해시가 로그 파일에 남아, 로그 열람 권한자가 오프라인 사전 공격으로 원문 비밀번호를 복구할 수 있습니다(salt가 userId뿐이라 더 취약).

## 변경

- 로그에서 `encPassword`만 제거하고 `userId`·`userSe`는 유지(디버깅 맥락 보존). 로그 문장 1줄.
- 로직 변경 없음.

## 검증 (TDD)

회귀 테스트 `EgovLoginManageServiceLogTest`를 추가했습니다. Logback `ListAppender`로 `actionLogin` 실행 중 로그를 수집하고, `encryptPassword`(private)를 리플렉션으로 호출해 **실제로 로깅될 해시값**을 구한 뒤, 어떤 로그 이벤트에도 그 값이 없음을 단언합니다.

- 수정 전: 테스트 **실패**(`encPassword = hJot2wEaeg1T...` 노출 실측)
- 수정 후: 테스트 **통과** (`mvn -pl EgovLogin test`, Tests run: 1, Failures: 0)

## 참고

- 파일 전체에서 `encPassword`가 **로그로 출력되는 지점은 이 한 곳(actionLogin)뿐**입니다. 다른 `encryptPassword` 사용처(`loginIncorrectProcess`)는 비밀번호 비교용이며 로깅하지 않습니다.