### PR TITLE
test(questionnaire): 설문 항목 등록 서비스 테스트 추가

### DIFF
--- a/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qim/service/impl/EgovQustnrItemServiceImplTest.java
+++ b/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qim/service/impl/EgovQustnrItemServiceImplTest.java
@@ -1,0 +1,133 @@
+package egovframework.com.uss.olp.qim.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import egovframework.com.uss.olp.qim.entity.QestnrInfo;
+import egovframework.com.uss.olp.qim.entity.QestnrInfoId;
+import egovframework.com.uss.olp.qim.entity.QustnrQesitm;
+import egovframework.com.uss.olp.qim.entity.QustnrQesitmId;
+import egovframework.com.uss.olp.qim.repository.EgovQestnrInfoRepository;
+import egovframework.com.uss.olp.qim.repository.EgovQustnrQesitmRepository;
+import egovframework.com.uss.olp.qim.service.EgovQustnrItemService;
+import egovframework.com.uss.olp.qim.service.QustnrIemVO;
+import egovframework.com.uss.olp.qmc.entity.QustnrTmplat;
+import egovframework.com.uss.olp.qmc.repository.EgovQustnrTmplatRepository;
+import lombok.extern.slf4j.Slf4j;
+
+@SpringBootTest
+@Transactional
+@Slf4j
+class EgovQustnrItemServiceImplTest {
+
+	@Autowired
+	private EgovQustnrItemService egovQustnrItemService;
+
+	@Autowired
+	private EgovQustnrQesitmRepository egovQustnrQesitmRepository;
+
+	@Autowired
+	private EgovQestnrInfoRepository egovQestnrInfoRepository;
+
+	@Autowired
+	private EgovQustnrTmplatRepository egovQustnrTmplatRepository;
+
+	@Test
+	void insert() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		String now2 = now.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+		DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+		String qustnrBgnde = now.format(dateFormatter);
+		String qustnrEndde = now.plusDays(1).format(dateFormatter);
+		String testId = "TEST_" + now2;
+		String testText = "test 이백행_" + now2;
+		String qustnrTmplatId = testId;
+		String qestnrId = testId;
+		String qustnrQesitmId = testId;
+		String uniqId = testId;
+
+		QustnrTmplat template = new QustnrTmplat();
+		template.setQustnrTmplatId(qustnrTmplatId);
+		template.setQustnrTmplatTy("1");
+		template.setQustnrTmplatDc(testText + "_설문 템플릿 설명");
+		template.setQustnrTmplatPathNm("test");
+		template.setFrstRegistPnttm(now);
+		template.setFrstRegisterId(uniqId);
+		template.setLastUpdtPnttm(now);
+		template.setLastUpdusrId(uniqId);
+		egovQustnrTmplatRepository.save(template);
+
+		QestnrInfoId surveyId = new QestnrInfoId();
+		surveyId.setQustnrTmplatId(qustnrTmplatId);
+		surveyId.setQestnrId(qestnrId);
+
+		QestnrInfo survey = new QestnrInfo();
+		survey.setQestnrInfoId(surveyId);
+		survey.setQustnrSj(testText + "_설문 제목");
+		survey.setQustnrPurps(testText + "_설문 목적");
+		survey.setQustnrWritingGuidanceCn(testText + "_설문 작성 안내");
+		survey.setQustnrTrget(testText + "_설문 대상");
+		survey.setQustnrBgnde(qustnrBgnde);
+		survey.setQustnrEndde(qustnrEndde);
+		survey.setFrstRegistPnttm(now);
+		survey.setFrstRegisterId(uniqId);
+		survey.setLastUpdtPnttm(now);
+		survey.setLastUpdusrId(uniqId);
+		egovQestnrInfoRepository.save(survey);
+
+		QustnrQesitmId parentId = new QustnrQesitmId();
+		parentId.setQustnrTmplatId(qustnrTmplatId);
+		parentId.setQestnrId(qestnrId);
+		parentId.setQustnrQesitmId(qustnrQesitmId);
+
+		QustnrQesitm parent = new QustnrQesitm();
+		parent.setQustnrQesitmId(parentId);
+		parent.setQestnSn("1");
+		parent.setQestnTyCode("1");
+		parent.setQestnCn(testText + "_설문 문항 내용");
+		parent.setMxmmChoiseCo("1");
+		parent.setFrstRegistPnttm(now);
+		parent.setFrstRegisterId(uniqId);
+		parent.setLastUpdtPnttm(now);
+		parent.setLastUpdusrId(uniqId);
+		egovQustnrQesitmRepository.save(parent);
+
+		QustnrIemVO qustnrIemVO = new QustnrIemVO();
+		qustnrIemVO.setQustnrTmplatId(qustnrTmplatId);
+		qustnrIemVO.setQestnrId(qestnrId);
+		qustnrIemVO.setQustnrQesitmId(qustnrQesitmId);
+		qustnrIemVO.setIemSn("999");
+		qustnrIemVO.setIemCn(testText + "_설문 항목 내용");
+		qustnrIemVO.setEtcAnswerAt("N");
+
+		Map<String, String> userInfo = new HashMap<>();
+		userInfo.put("uniqId", uniqId);
+
+		// when
+		QustnrIemVO result = egovQustnrItemService.insert(qustnrIemVO, userInfo);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getQustnrIemId()).isNotBlank();
+		assertThat(result.getIemSn()).isEqualTo(qustnrIemVO.getIemSn());
+		assertThat(result.getIemCn()).isEqualTo(qustnrIemVO.getIemCn());
+		assertThat(result.getEtcAnswerAt()).isEqualTo(qustnrIemVO.getEtcAnswerAt());
+		assertThat(result.getFrstRegisterId()).isEqualTo(userInfo.get("uniqId"));
+		assertThat(result.getLastUpdusrId()).isEqualTo(userInfo.get("uniqId"));
+		assertThat(result.getFrstRegistPnttm()).isNotNull();
+		assertThat(result.getLastUpdtPnttm()).isNotNull();
+
+		log.debug("qustnrIemId={}", result.getQustnrIemId());
+		log.debug("iemCn={}", result.getIemCn());
+	}
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

`EgovQustnrItemServiceImpl.insert`의 설문 항목 등록 동작을 검증하는 테스트를 추가합니다.

실제 Spring 애플리케이션 컨텍스트와 Repository를 사용하여 상위 설문 데이터를 준비한 후 설문 항목을 등록하고, 반환 결과와 등록·수정 정보를 검증합니다.

###  변경 사유

설문 항목은 설문 템플릿, 설문 정보 및 설문 문항을 외래 키로 참조합니다.

따라서 설문 항목만 단독으로 등록하면 외래 키 제약 조건으로 테스트가 실패할 수 있습니다. 테스트에서 상위 데이터를 참조 순서에 맞게 생성하여 실제 등록 흐름을 안정적으로 검증하도록 구성했습니다.

###  주요 변경 사항

- `EgovQustnrItemServiceImplTest` 추가
- `@SpringBootTest`를 이용한 Spring 통합 테스트 환경 구성
- Mockito를 사용하지 않고 실제 서비스와 Repository 주입
- `given / when / then` 구조로 테스트 단계 구분
- 외래 키 관계에 따라 다음 데이터를 순서대로 생성
  1. 설문 템플릿
  2. 설문 정보
  3. 설문 문항
  4. 설문 항목
- `LocalDateTime`을 이용하여 실행 시점 기반의 테스트 데이터 생성
  - 식별자: `TEST_yyyyMMddHHmmss`
  - 테스트 문구: `test 이백행_yyyyMMddHHmmss`
- 설문 시작일을 테스트 실행일로 설정
- 설문 종료일을 테스트 실행일의 다음 날로 설정
- `@Transactional`을 적용하여 테스트 데이터 롤백

###  검증 항목

- 등록 결과가 `null`이 아닌지 확인
- 설문 항목 ID가 생성되었는지 확인
- 항목 순번이 요청값과 일치하는지 확인
- 항목 내용이 요청값과 일치하는지 확인
- 기타 답변 여부가 요청값과 일치하는지 확인
- 최초 등록자가 요청한 사용자 ID와 일치하는지 확인
- 최종 수정자가 요청한 사용자 ID와 일치하는지 확인
- 최초 등록 일시가 생성되었는지 확인
- 최종 수정 일시가 생성되었는지 확인

###  변경 파일

- `EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qim/service/impl/EgovQustnrItemServiceImplTest.java`

###  테스트 환경

- Java: `E:\eGovCI-5.0.0-Windows-64bit\bin\jdk-17.0.17+10`
- Maven: `E:\eGovCI-5.0.0-Windows-64bit\bin\apache-maven-3.9.9`
- Spring Boot: `3.5.6`
- 데이터베이스: MySQL `8.0.33`

###  테스트 방법

```shell
mvn -f EgovQuestionnaire/pom.xml -Dtest=EgovQustnrItemServiceImplTest test
```

###  테스트 결과

```text
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

###  영향 범위

- 운영 코드 변경 없음
- 데이터베이스 스키마 변경 없음
- 외부 API 변경 없음
- `EgovQuestionnaire` 모듈의 설문 항목 등록 테스트만 추가

```
SELECT * FROM COMTNQUSTNRTMPLAT /* 설문템플릿 */;

SELECT * FROM COMTNQESTNRINFO /* 설문지정보 */;

SELECT * FROM COMTNQUSTNRQESITM /* 설문문항 */;

SELECT * FROM COMTNQUSTNRIEM /* 설문항목 */;
```

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/53f439c5-67a4-464d-97da-292483edfb9f" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/78692a97-a88a-40ab-b97b-2799b26de8ea" />
