### PR TITLE
fix(GatewayServer): 모바일 신분증 경로 오타 수정

### DIFF
--- a/GatewayServer/src/main/java/egovframework/com/filter/AuthGatewayFilterFactory.java
+++ b/GatewayServer/src/main/java/egovframework/com/filter/AuthGatewayFilterFactory.java
@@ -197,7 +197,7 @@ public class AuthGatewayFilterFactory extends AbstractGatewayFilterFactory<AuthG
     }
 
     private String getParamFromPath(String path) {
-        if (path.contains("/uat/uap") || path.contains("/mpi")) {
+        if (path.contains("/uat/uap") || path.contains("/mip")) {
             return "1";
         } else if (path.contains("/sec")) {
             return "2";

--- a/GatewayServer/src/test/java/egovframework/com/filter/AuthGatewayFilterFactoryTest.java
+++ b/GatewayServer/src/test/java/egovframework/com/filter/AuthGatewayFilterFactoryTest.java
@@ -1,0 +1,23 @@
+package egovframework.com.filter;
+
+import egovframework.com.config.GatewayJwtProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AuthGatewayFilterFactoryTest {
+
+    @Test
+    void getParamFromPathReturnsLoginCategoryForMobileIdPath() {
+        AuthGatewayFilterFactory filterFactory = new AuthGatewayFilterFactory(
+                WebClient.builder(), mock(GatewayJwtProvider.class));
+
+        String pathCode = ReflectionTestUtils.invokeMethod(
+                filterFactory, "getParamFromPath", "/mip/main");
+
+        assertThat(pathCode).isEqualTo("1");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

Gateway에서 접근이 거부된 요청의 경로를 분류할 때 모바일 신분증 경로가 `/mpi`로 잘못 작성되어 있었습니다.

실제 모바일 신분증 경로인 `/mip/**` 요청을 정상적으로 분류할 수 있도록 `/mpi`를 `/mip`로 수정했습니다. 이에 따라 권한이 없는 사용자가 `/mip/**` 경로에 접근하면 로그인 접근 제한 페이지로 이동할 때 `pathCode=1`이 명시적으로 전달됩니다.

같은 문제가 다시 발생하지 않도록 `/mip/main` 경로의 분류 결과가 `1`인지 확인하는 단위 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 1. 일반회원 로그인 확인
일반회원 계정(`USER`)으로 정상 로그인한 상태입니다.

<img width="986" height="368" alt="화면 캡처 2026-08-31 204831" src="https://github.com/user-attachments/assets/d5286c71-d246-4aeb-bf1f-af41296dde79" />

### 2. 모바일 신분증 경로 접근 거부 확인
일반 회원이  `/mip/main`에 접근했을 때 권한 오류 화면으로 이동하며, 주소에 `pathCode=1`이 전달되는 것을 확인했습니다.

<img width="983" height="425" alt="화면 캡처 2026-08-31 204842" src="https://github.com/user-attachments/assets/d7e5a4b6-ecf0-415a-a479-c9cadbd5e08c" />

### 3. 단위 테스트 결과
`/mip/main` 경로가 `pathCode=1`로 분류되는지 확인하는 단위 테스트가 통과했습니다.

<img width="1224" height="487" alt="화면 캡처 2026-08-31 204946" src="https://github.com/user-attachments/assets/3b788093-c49a-4b7e-b49e-e3e2510ac24a" />
