### PR TITLE
fix(EgovBoard): 댓글 삭제가 화면이 보내는 요청을 400 으로 거절하는 문제 수정

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
@@ -93,15 +93,7 @@ public class EgovCommentAPIController {
     }
 
     @PostMapping("/deleteComment")
-    public ResponseEntity<?> deleteComment(@Valid @RequestBody CommentVO commentVO, BindingResult bindingResult, HttpServletRequest request) {
-        if (bindingResult.hasErrors()) {
-            Map<String, String> errors = new HashMap<>();
-            for (FieldError error : bindingResult.getFieldErrors()) {
-                errors.put(error.getField(), error.getDefaultMessage());
-            }
-            return ResponseEntity.badRequest().body(errors);
-        }
-
+    public ResponseEntity<?> deleteComment(@RequestBody CommentVO commentVO, HttpServletRequest request) {
         Map<String, String> userInfo = extracted(request);
         try {
             articleCommentService.deleteArticleComment(commentVO, userInfo);

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentDeleteRequestTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentDeleteRequestTest.java
@@ -1,0 +1,58 @@
+package egovframework.com.cop.brd.web;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import egovframework.com.cop.brd.service.EgovCommentService;
+import egovframework.com.cop.brd.service.EgovStsfdgService;
+import egovframework.com.pagination.EgovKrdsPaginationRenderer;
+import org.egovframe.boot.crypto.service.EgovEnvCryptoService;
+
+/**
+ * 댓글 삭제 요청 계약.
+ *
+ * 화면(boardDetail.html)은 삭제에 bbsId · nttId · answerNo 만 보내고
+ * 삭제 로직(EgovCommentServiceImpl#deleteArticleComment)도 그 셋만 쓴다.
+ *
+ * @author 최완택
+ * @since 2026-09-04
+ */
+@DisplayName("댓글 삭제 API 요청 계약")
+class EgovCommentDeleteRequestTest {
+
+	private static final String SCREEN_PAYLOAD =
+		"{\"bbsId\":\"BBSMSTR_000000000001\",\"nttId\":1,\"answerNo\":1}";
+
+	@Test
+	@DisplayName("화면이 보내는 삭제 요청을 400 으로 거절하지 않는다")
+	void acceptsPayloadTheScreenSends() throws Exception {
+		EgovEnvCryptoService crypto = mock(EgovEnvCryptoService.class);
+		when(crypto.decrypt(anyString())).thenReturn("USRCNFRM_00000000000");
+
+		EgovCommentAPIController controller = new EgovCommentAPIController(
+			mock(EgovCommentService.class),
+			mock(EgovStsfdgService.class),
+			crypto,
+			mock(EgovKrdsPaginationRenderer.class));
+
+		MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+		mockMvc.perform(post("/cop/brd/deleteComment")
+				.contentType(MediaType.APPLICATION_JSON)
+				.header("X-USER-ID", "encrypted")
+				.header("X-USER-NM", "encrypted")
+				.header("X-UNIQ-ID", "encrypted")
+				.content(SCREEN_PAYLOAD))
+			.andExpect(status().isOk());
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovCommentAPIController:96` 의 `deleteComment` 가 `@Valid` 로 `CommentVO` 전체를 검증합니다.

```java
public ResponseEntity<?> deleteComment(@Valid @RequestBody CommentVO commentVO, BindingResult bindingResult, HttpServletRequest request) {
```

`CommentVO:30` 의 `answer` 에는 `@EgovNullCheck` 가 걸려 있습니다. 이 애노테이션은 `jakarta.validation.Constraint` 이고 검증기가 `ObjectUtils.isEmpty` 로 판정하므로 값이 없으면 위반이 됩니다.

```java
@EgovNullCheck(message = "{comCopBbs.boardMasterVO.detail.option2}{common.required.msg}")
private String answer;
```

그런데 화면은 삭제 요청에 `answer` 를 보내지 않습니다. `boardDetail.html:470` 이 세 값만 실어 보냅니다.

```javascript
body: JSON.stringify({ bbsId: bbsId, nttId: nttId, answerNo: answerNo })
```

삭제 로직도 그 셋만 씁니다. `EgovCommentServiceImpl:68` 의 `deleteArticleComment` 는 `bbsId`·`nttId`·`answerNo` 로 `CommentId` 를 만들어 조회하고 소유자를 대조할 뿐 `answer` 를 읽지 않습니다. 그래서 화면의 삭제 버튼은 검증 단계에서 막혀 400 을 받습니다.

형제 경로는 삭제에 검증을 걸지 않습니다. 저장소의 삭제 핸들러 열여덟 가운데 `@Valid` 가 붙은 것은 `deleteComment` 하나입니다.

```
$ G='public [A-Za-z0-9_<>?,. ]+ [A-Za-z0-9_]*[Dd]elete[A-Za-z0-9_]*\('
$ git grep -nE "$G" origin/main -- '*/src/main/java/*/web/*.java' | wc -l
18
$ git grep -nE "$G" origin/main -- '*/src/main/java/*/web/*.java' | grep '@Valid'
origin/main:EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java:96:    public ResponseEntity<?> deleteComment(@Valid @RequestBody CommentVO commentVO, BindingResult bindingResult, HttpServletRequest request) {
```

`deleteBoard` 와 `deleteStsfdg` 는 #56(`186121f`, 2026-09-04 머지)에서 실행되지 않는 `BindingResult` 분기를 걷어낸 자리입니다. 그 둘은 `@Valid` 가 없어 분기가 죽어 있었고, `deleteComment` 는 `@Valid` 가 있어 분기가 살아 있습니다. 살아 있는 쪽이 이 문제입니다.

AS-IS

```java
public ResponseEntity<?> deleteComment(@Valid @RequestBody CommentVO commentVO, BindingResult bindingResult, HttpServletRequest request) {
    if (bindingResult.hasErrors()) {
        Map<String, String> errors = new HashMap<>();
        for (FieldError error : bindingResult.getFieldErrors()) {
            errors.put(error.getField(), error.getDefaultMessage());
        }
        return ResponseEntity.badRequest().body(errors);
    }

    Map<String, String> userInfo = extracted(request);
```

TO-BE

```java
public ResponseEntity<?> deleteComment(@RequestBody CommentVO commentVO, HttpServletRequest request) {
    Map<String, String> userInfo = extracted(request);
```

### 영향 범위

같은 파일의 `insertComment:76` 은 그대로 두었습니다. 등록은 `answer` 를 직접 읽으므로(`:88` `if (!commentVO.getAnswer().isEmpty())`) 그 경로에서는 `@Valid` 가 필요합니다.

`deleteComment` 의 소유자 대조와 예외 처리는 손대지 않았습니다.

이 시그니처를 `git blame` 하면 `3251f63`(NCSC 보안점검 조치 적용)이 잡히지만 `@Valid` 는 그 커밋 이전부터 있었습니다. 그 커밋이 이 시그니처에 더한 것은 `HttpServletRequest request` 입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

화면이 보내는 본문을 그대로 던지는 테스트를 함께 넣었습니다.

수정 전에는 이렇게 실패합니다.

```
[ERROR] Failures:
[ERROR]   EgovCommentDeleteRequestTest.acceptsPayloadTheScreenSends:55 Status expected:<200> but was:<400>
```

무엇이 막았는지는 `andDo(print())` 를 임시로 넣고 다시 돌리면 보입니다.

```
MockHttpServletResponse:
           Status = 400
    Error message = null
          Headers = [Content-Type:"application/json"]
     Content type = application/json
             Body = {"answer":"{comCopBbs.boardMasterVO.detail.option2}{common.required.msg}"}
```

수정 후에는 모듈 테스트가 모두 통과합니다. #56 이 넣은 검증 계약 테스트도 함께 돕니다.

```
$ mvn -B test
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 s -- in API 컨트롤러 검증 계약
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.681 s -- in 댓글 삭제 API 요청 계약
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.067 s -- in egovframework.com.cop.bbs.service.impl.EgovBbsMasterServiceImplTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

API 컨트롤러 수정이라 브라우저 테스트는 하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경이 없어 위 「JUnit 테스트」 절의 출력으로 대신합니다.
