### PR TITLE
fix(EgovBoard): 게시판 옵션 조회 시 중복 findById 호출 제거

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBbsMasterServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBbsMasterServiceImpl.java
@@ -90,11 +90,9 @@ public class EgovBbsMasterServiceImpl extends EgovAbstractServiceImpl implements
 
     @Override
     public BbsMasterOptnVO selectBBSMasterOptn(String bbsId) {
-        if (optnRepository.findById(bbsId).isPresent()) {
-            return EgovBoardUtility.bbsmasteroptnEntityToVO(optnRepository.findById(bbsId).get());
-        } else {
-            return null;
-        }
+        return optnRepository.findById(bbsId)
+                .map(EgovBoardUtility::bbsmasteroptnEntityToVO)
+                .orElse(null);
     }
 
     @Override

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovBbsMasterServiceImplTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovBbsMasterServiceImplTest.java
@@ -1,0 +1,62 @@
+package egovframework.com.cop.brd.service.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import egovframework.com.cop.brd.entity.BbsMasterOptn;
+import egovframework.com.cop.brd.repository.EgovBbsMasterOptnRepository;
+import egovframework.com.cop.brd.repository.EgovBbsMasterRepository;
+import egovframework.com.cop.brd.service.BbsMasterOptnVO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EgovBbsMasterServiceImplTest {
+
+    @Mock
+    private EgovBbsMasterOptnRepository optnRepository;
+
+    @Mock
+    private EgovBbsMasterRepository masterRepository;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    private EgovBbsMasterServiceImpl service;
+
+    @Test
+    void selectBBSMasterOptnFindsOptionOnce() {
+        String bbsId = "BBSMSTR_000000000001";
+        BbsMasterOptn option = new BbsMasterOptn();
+        option.setBbsId(bbsId);
+        option.setAnswerAt("Y");
+        option.setStsfdgAt("N");
+        when(optnRepository.findById(bbsId)).thenReturn(Optional.of(option));
+
+        BbsMasterOptnVO result = service.selectBBSMasterOptn(bbsId);
+
+        assertThat(result.getBbsId()).isEqualTo(bbsId);
+        assertThat(result.getAnswerAt()).isEqualTo("Y");
+        assertThat(result.getStsfdgAt()).isEqualTo("N");
+        verify(optnRepository).findById(bbsId);
+    }
+
+    @Test
+    void selectBBSMasterOptnReturnsNullWhenOptionDoesNotExist() {
+        String bbsId = "BBSMSTR_000000000001";
+        when(optnRepository.findById(bbsId)).thenReturn(Optional.empty());
+
+        BbsMasterOptnVO result = service.selectBBSMasterOptn(bbsId);
+
+        assertThat(result).isNull();
+        verify(optnRepository).findById(bbsId);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`selectBBSMasterOptn`에서 게시판 옵션이 존재할 경우 `findById`가 두 번 호출되고 있었습니다.

조회 결과를 `Optional.map`으로 변환하도록 수정하여 데이터베이스 조회가 한 번만 실행되도록 했습니다. 게시판 옵션이 없는 경우에는 기존과 동일하게 `null`을 반환합니다.


## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

다음 경우를 테스트했습니다.

- 게시판 옵션이 존재할 때 정상적으로 `BbsMasterOptnVO`가 반환되는지 확인
- 게시판 옵션이 없을 때 기존과 동일하게 `null`이 반환되는지 확인
- 두 경우 모두 `optnRepository.findById`가 한 번만 호출되는지 확인
- 게시판 목록 및 게시글 상세 화면이 정상적으로 표시되는지 확인
- 게시판 옵션에 따라 답글 버튼과 댓글 입력 영역이 정상적으로 표시되는지 확인

테스트 결과: 2건 성공, 실패 및 오류 없음

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 게시판 목록 조회

게시판 목록에서 테스트 게시글이 정상적으로 조회되는 것을 확인

<img width="1112" height="507" alt="image" src="https://github.com/user-attachments/assets/71741383-8407-4e9d-ab0e-a8d7a57a301b" />


### 게시글 상세 조회

게시글 상세 화면에 정상적으로 진입하고, 게시판 옵션에 따른 답글 버튼과 댓글 입력 영역이 표시되는 것을 확인

<img width="1109" height="787" alt="image" src="https://github.com/user-attachments/assets/f4d82a04-fe44-4a46-a36a-2d38677e17de" />


### JUnit 테스트

게시판 옵션 존재 여부에 대한 테스트 2건이 모두 통과하고, 각 테스트에서 `findById`가 한 번만 호출되는 것을 확인했습니다.

<img width="1551" height="494" alt="화면 캡처 2026-09-05 134729" src="https://github.com/user-attachments/assets/e2bfbb35-d8bd-4b8a-a5ec-48686d6a2f3b" />
