### PR TITLE
fix(EgovBoard): 댓글 삭제 시 불필요한 내용 검증 제거

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
@@ -93,15 +93,7 @@ public class EgovCommentAPIController {
     }
 
     @PostMapping("/deleteComment")
-    public ResponseEntity<?> deleteComment(@Valid @RequestBody CommentVO commentVO, BindingResult bindingResult, HttpServletRequest request) {
-        if (bindingResult.hasErrors()) {
-            Map<String, String> errors = new HashMap<>();
-            for (FieldError error : bindingResult.getFieldErrors()) {
-                errors.put(error.getField(), error.getDefaultMessage());
-            }
-            return ResponseEntity.badRequest().body(errors);
-        }
-
+    public ResponseEntity<?> deleteComment(@RequestBody CommentVO commentVO, HttpServletRequest request) {
         Map<String, String> userInfo = extracted(request);
         try {
             articleCommentService.deleteArticleComment(commentVO, userInfo);

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentAPIControllerTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentAPIControllerTest.java
@@ -1,0 +1,77 @@
+package egovframework.com.cop.brd.web;
+
+import egovframework.com.cop.brd.service.CommentVO;
+import egovframework.com.cop.brd.service.EgovCommentService;
+import egovframework.com.cop.brd.service.EgovStsfdgService;
+import egovframework.com.pagination.EgovKrdsPaginationRenderer;
+import org.egovframe.boot.crypto.service.EgovEnvCryptoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class EgovCommentAPIControllerTest {
+
+    @Mock
+    private EgovCommentService commentService;
+
+    @Mock
+    private EgovStsfdgService stsfdgService;
+
+    @Mock
+    private EgovEnvCryptoService cryptoService;
+
+    @Mock
+    private EgovKrdsPaginationRenderer paginationRenderer;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        EgovCommentAPIController controller = new EgovCommentAPIController(
+                commentService, stsfdgService, cryptoService, paginationRenderer);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void deleteCommentDoesNotRequireAnswer() throws Exception {
+        when(cryptoService.decrypt(anyString())).thenReturn("test-user");
+
+        mockMvc.perform(post("/cop/brd/deleteComment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-USER-ID", "encrypted-user-id")
+                        .header("X-USER-NM", "encrypted-user-name")
+                        .header("X-UNIQ-ID", "encrypted-uniq-id")
+                        .content("""
+                                {
+                                  "bbsId": "BBSMSTR_000000000001",
+                                  "nttId": 1,
+                                  "answerNo": 1
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<CommentVO> commentCaptor = ArgumentCaptor.forClass(CommentVO.class);
+        verify(commentService).deleteArticleComment(commentCaptor.capture(), anyMap());
+
+        CommentVO comment = commentCaptor.getValue();
+        assertThat(comment.getBbsId()).isEqualTo("BBSMSTR_000000000001");
+        assertThat(comment.getNttId()).isEqualTo(1L);
+        assertThat(comment.getAnswerNo()).isEqualTo(1L);
+        assertThat(comment.getAnswer()).isNull();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

댓글 삭제 요청에는 `bbsId`, `nttId`, `answerNo`만 전달되지만, 삭제 API에서 `CommentVO` 전체에 대한 검증을 수행하고 있었습니다.

이 과정에서 댓글 등록 시에만 필요한 `answer` 필드의 `@EgovNullCheck` 검증이 삭제 요청에도 적용되어, 정상적인 삭제 요청이 `댓글은(는) 필수입력항목입니다.` 오류로 실패했습니다.

댓글 삭제 API에서 `@Valid`와 `BindingResult`를 제거하여 삭제에 필요한 식별 정보만으로 요청을 처리하도록 수정했습니다.

또한 `answer` 값이 없는 댓글 삭제 요청이 정상 처리되고 삭제 서비스가 호출되는지 확인하는 컨트롤러 테스트를 추가했습니다.


## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

실행 테스트:

- `EgovCommentAPIControllerTest`
- Tests run: 1
- Failures: 0
- Errors: 0
- Skipped: 0

수동 테스트:

1. 일반회원으로 로그인
2. 게시글 상세 화면에서 댓글 등록
3. 등록한 댓글의 삭제 버튼 선택
4. 삭제 확인 창에서 확인 선택
5. 필수 입력값 경고 없이 댓글이 정상적으로 삭제되는 것을 확인

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

댓글 삭제 시 `댓글은(는) 필수입력항목입니다.` 경고가 표시되고 삭제되지 않는 화면

<img width="1277" height="718" alt="image" src="https://github.com/user-attachments/assets/9433967b-a3b3-4716-af20-ef3fabd0e398" />


### 수정 후

동일한 절차로 댓글이 정상적으로 삭제된 화면

<img width="1486" height="932" alt="image" src="https://github.com/user-attachments/assets/49e34e1d-6ec5-452d-a5d7-51f488425110" />


### JUnit 테스트

`EgovCommentAPIControllerTest` 실행 성공 화면

<img width="1267" height="487" alt="image" src="https://github.com/user-attachments/assets/94550e02-0e80-46aa-b691-020947306f16" />
