### PR TITLE
fix(EgovBoard): 게시글 수정 시 중복 저장 호출 제거

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImpl.java
@@ -352,8 +352,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
             bbsVO.setLastUpdtPnttm(String.valueOf(LocalDateTime.now()));
             bbsVO.setLastUpdusrId(userInfo.get("uniqId"));
 
-            repository.save(EgovBoardUtility.bbsVOToEntity(bbsVO));
-
             bbsVO = EgovBoardUtility.bbsEntityToVO(repository.save(EgovBoardUtility.bbsVOToEntity(bbsVO)));
 
             syncLogProcess(bbsVO);

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImplTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImplTest.java
@@ -1,0 +1,136 @@
+package egovframework.com.cop.brd.service.impl;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Expression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import egovframework.com.cop.brd.entity.Bbs;
+import egovframework.com.cop.brd.entity.BbsId;
+import egovframework.com.cop.brd.entity.QBbs;
+import egovframework.com.cop.brd.entity.QBbsMaster;
+import egovframework.com.cop.brd.entity.QUserMaster;
+import egovframework.com.cop.brd.repository.EgovBbsSyncLogRepository;
+import egovframework.com.cop.brd.repository.EgovBoardRepository;
+import egovframework.com.cop.brd.repository.EgovCommentRepository;
+import egovframework.com.cop.brd.service.BbsVO;
+import egovframework.com.cop.brd.service.EgovFileService;
+import egovframework.com.cop.brd.util.EgovFileUtility;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.stream.function.StreamBridge;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EgovBoardServiceImplTest {
+
+    @Mock
+    private EgovBoardRepository repository;
+
+    @Mock
+    private EgovBbsSyncLogRepository bbsSyncLogRepository;
+
+    @Mock
+    private EgovCommentRepository commentRepository;
+
+    @Mock
+    private EgovFileUtility fileUtility;
+
+    @Mock
+    private EgovFileService fileService;
+
+    @Mock
+    private EgovIdGnrService boardIdGnrService;
+
+    @Mock
+    private EgovIdGnrService bbsSyncLogIdGnrService;
+
+    @Mock
+    private StreamBridge streamBridge;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    private EgovBoardServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EgovBoardServiceImpl(
+                repository,
+                bbsSyncLogRepository,
+                commentRepository,
+                fileUtility,
+                fileService,
+                boardIdGnrService,
+                bbsSyncLogIdGnrService,
+                streamBridge,
+                queryFactory);
+    }
+
+    @Test
+    void updateSavesBoardOnce() throws Exception {
+        Bbs existingBoard = createExistingBoard();
+        when(repository.findById(existingBoard.getBbsId())).thenReturn(Optional.of(existingBoard));
+
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.get(QBbs.bbs)).thenReturn(existingBoard);
+        when(tuple.get(QUserMaster.userMaster)).thenReturn(null);
+        when(tuple.get(QBbsMaster.bbsMaster)).thenReturn(null);
+
+        @SuppressWarnings("unchecked")
+        JPAQuery<Tuple> detailQuery = mock(JPAQuery.class, RETURNS_SELF);
+        when(queryFactory.select(any(Expression[].class))).thenReturn(detailQuery);
+        when(detailQuery.fetchOne()).thenReturn(tuple);
+        when(repository.save(any(Bbs.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        BbsVO board = new BbsVO();
+        board.setBbsId(existingBoard.getBbsId().getBbsId());
+        board.setNttId(existingBoard.getBbsId().getNttId());
+        board.setNttSj("수정된 제목");
+        board.setNttCn("수정된 내용");
+
+        BbsVO result = service.update(
+                board,
+                Collections.emptyList(),
+                Map.of("uniqId", existingBoard.getFrstRegisterId()));
+
+        verify(repository, times(1)).save(any(Bbs.class));
+        assertThat(result.getNttSj()).isEqualTo("수정된 제목");
+        assertThat(result.getNttCn()).isEqualTo("수정된 내용");
+    }
+
+    private Bbs createExistingBoard() {
+        BbsId id = new BbsId();
+        id.setBbsId("BBSMSTR_000000000001");
+        id.setNttId(1L);
+
+        Bbs board = new Bbs();
+        board.setBbsId(id);
+        board.setNttNo(1);
+        board.setRdcnt(0);
+        board.setParntscttNo(0);
+        board.setAnswerLc(0);
+        board.setSortOrdr(0);
+        board.setNttSj("기존 제목");
+        board.setNttCn("기존 내용");
+        board.setFrstRegisterId("USRCNFRM_00000000000");
+        board.setFrstRegistPnttm(LocalDateTime.now());
+        board.setUseAt("Y");
+        return board;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시글 수정 처리에서 동일한 `bbsVO`를 엔티티로 변환한 뒤 `repository.save()`를 연속으로 두 번 호출하고 있었습니다.

첫 번째 호출의 반환값은 사용되지 않으며, 두 번째 호출에서 동일한 데이터를 다시 저장한 뒤 저장 결과를 `BbsVO`로 변환하고 있었습니다.

저장 결과를 사용하는 두 번째 호출만 유지하여 불필요한 저장소 호출을 제거했습니다. 게시글 수정 결과 반환과 검색 동기화 처리 방식은 기존과 동일하게 유지됩니다.

또한 게시글 수정 시 `repository.save()`가 한 번만 호출되고, 수정한 제목과 내용이 정상적으로 반환되는지 확인하는 단위 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

실행 결과:

- `EgovBoardServiceImplTest.updateSavesBoardOnce`
- EgovBoard 전체 테스트 3건 통과
- Failures: 0
- Errors: 0
- Skipped: 0

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 코드 수정 후 기능 정상 작동 확인


https://github.com/user-attachments/assets/4ff80744-c330-47d3-b15f-4a6bfb868761



### JUnit 테스트 결과

`EgovBoardServiceImplTest.updateSavesBoardOnce` 및 EgovBoard 전체 테스트가 정상적으로 통과한 화면

<img width="1248" height="488" alt="image" src="https://github.com/user-attachments/assets/9411604d-8928-49c9-adee-14e3ada9ee27" />
