### PR TITLE
fix(EgovBoard): 첨부파일 생성일시 중복 설정 제거

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovFileServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovFileServiceImpl.java
@@ -69,7 +69,6 @@ public class EgovFileServiceImpl extends EgovAbstractServiceImpl implements Egov
 
         file.setAtchFileId(fvo.getAtchFileId());
         file.setUseAt("Y");
-        file.setCreatDt(LocalDateTime.now());
 
         String candidateFileSn = fvo.getFileSn().isEmpty() ? "0" : fvo.getFileSn();
         FileDetailId filedetailId = new FileDetailId();


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovFileServiceImpl.insertFileInf()`에서 첨부파일 생성일시를 중복으로 설정하고 있었습니다.

앞에서 설정한 값은 파일 저장 전에 다시 설정되어 사용되지 않으므로, 불필요한 생성일시 설정 코드를 제거했습니다.

실제 저장 직전의 생성일시 설정은 그대로 유지했습니다.

## JUnit 테스트 JUnit tests

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

EgovBoard 전체 테스트 7개가 통과했습니다.

## 테스트 브라우저 Test Browser

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

첨부파일 첨부 및 다운로드 정상 확인

https://github.com/user-attachments/assets/7e0c0721-be40-4619-bec7-fbd2af0fa0e5

Junit 테스트 결과

<img width="1258" height="481" alt="image" src="https://github.com/user-attachments/assets/fde338e0-30df-497a-8758-781e0e9e829a" />



