### PR TITLE
fix(EgovBoard): 존재하지 않는 만족도 삭제 요청이 200 으로 응답하던 문제 수정

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovStsfdgServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovStsfdgServiceImpl.java
@@ -95,7 +95,7 @@ public class EgovStsfdgServiceImpl extends EgovAbstractServiceImpl implements Eg
 
         Optional<Stsfdg> optionalStsfdg = egovStsfdgRepository.findById(stsfdgNo);
         if (optionalStsfdg.isEmpty()) {
-            return 0;
+            throw new IllegalStateException("만족도를 찾을 수 없습니다.");
         }
 
         Stsfdg stsfdg = optionalStsfdg.get();

--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
@@ -178,6 +178,9 @@ public class EgovCommentAPIController {
             if ("인증 정보가 없습니다.".equals(msg)) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(msg);
             }
+            if ("만족도를 찾을 수 없습니다.".equals(msg)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(msg);
+            }
             if (msg != null && msg.contains("권한")) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body(msg);
             }

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovStsfdgServiceImplTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovStsfdgServiceImplTest.java
@@ -1,0 +1,42 @@
+package egovframework.com.cop.brd.service.impl;
+
+import egovframework.com.cop.brd.repository.EgovStsfdgRepository;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EgovStsfdgServiceImplTest {
+
+    @Mock
+    private EgovStsfdgRepository egovStsfdgRepository;
+
+    @Mock
+    private EgovIdGnrService idgenServiceStsfdgNo;
+
+    private EgovStsfdgServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EgovStsfdgServiceImpl(egovStsfdgRepository, idgenServiceStsfdgNo);
+    }
+
+    @Test
+    void deleteStsfdgThrowsWhenRowMissing() {
+        when(egovStsfdgRepository.findById("STSFDG_00000000999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.deleteStsfdg("STSFDG_00000000999",
+                Map.of("uniqId", "USRCNFRM_00000000000")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("만족도를 찾을 수 없습니다.");
+    }
+}

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentAPIControllerTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentAPIControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -73,5 +74,24 @@ class EgovCommentAPIControllerTest {
         assertThat(comment.getNttId()).isEqualTo(1L);
         assertThat(comment.getAnswerNo()).isEqualTo(1L);
         assertThat(comment.getAnswer()).isNull();
+    }
+
+    @Test
+    void deleteStsfdgReturnsNotFoundWhenRowMissing() throws Exception {
+        when(cryptoService.decrypt(anyString())).thenReturn("test-user");
+        doThrow(new IllegalStateException("만족도를 찾을 수 없습니다."))
+                .when(stsfdgService).deleteStsfdg(anyString(), anyMap());
+
+        mockMvc.perform(post("/cop/brd/deleteStsfdg")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-USER-ID", "encrypted-user-id")
+                        .header("X-USER-NM", "encrypted-user-name")
+                        .header("X-UNIQ-ID", "encrypted-uniq-id")
+                        .content("""
+                                {
+                                  "stsfdgNo": "STSFDG_00000000999"
+                                }
+                                """))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시판 모듈의 댓글·게시글 삭제 API 는 같은 계약을 공유합니다. 대상이 없으면 서비스가 `IllegalStateException("...를 찾을 수 없습니다.")` 를 던지고 컨트롤러의 `catch` 표가 그 메시지를 404 로 바꿉니다.

- 댓글: `EgovCommentServiceImpl.java:76-78` 의 `throw` → `EgovCommentAPIController.java:106-108` 의 `HttpStatus.NOT_FOUND`
- 게시글: `EgovBoardServiceImpl.java:367-368` 의 `orElseThrow` → `EgovBoardAPIController.java:209-211` 의 `HttpStatus.NOT_FOUND`

만족도 삭제에는 이 매핑이 없습니다. `EgovStsfdgServiceImpl.java:97-98` 이 조회 결과가 비면 예외 없이 `return 0;` 으로 빠져나갑니다. `EgovCommentAPIController.java:174-175` 는 그 반환값을 보지 않은 채 `ResponseEntity.ok().body("삭제되었습니다.")` 를 만듭니다. 같은 메서드의 `catch` 표(`:176-185`)에는 401 과 403 분기만 있습니다.

그래서 존재하지 않는 `stsfdgNo` 로 `POST /cop/brd/deleteStsfdg` 를 호출하면 삭제된 행이 없는데도 200 `삭제되었습니다.` 가 돌아옵니다. 같은 모양의 요청에 댓글 삭제와 게시글 삭제는 404 를 돌려줍니다.

AS-IS (`EgovStsfdgServiceImpl.java:96-99`)

```java
Optional<Stsfdg> optionalStsfdg = egovStsfdgRepository.findById(stsfdgNo);
if (optionalStsfdg.isEmpty()) {
    return 0;
}
```

TO-BE

```java
Optional<Stsfdg> optionalStsfdg = egovStsfdgRepository.findById(stsfdgNo);
if (optionalStsfdg.isEmpty()) {
    throw new IllegalStateException("만족도를 찾을 수 없습니다.");
}
```

`EgovCommentAPIController.deleteStsfdg` 의 `catch` 표에는 형제와 같은 문자열 비교 분기를 401 과 403 사이에 넣었습니다.

```java
if ("만족도를 찾을 수 없습니다.".equals(msg)) {
    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(msg);
}
```

### 영향 범위

응답이 달라지는 경로는 `POST /cop/brd/deleteStsfdg` 에 존재하지 않는 `stsfdgNo` 가 들어온 경우뿐입니다. 정상 삭제와 인증 실패(401)·권한 없음(403)·`stsfdgNo` 누락(400) 경로는 그대로입니다.

`boardDetail.html:581-583` 의 삭제 핸들러는 `response.ok` 를 보지 않고 응답 본문을 그대로 `alert` 합니다. 지금까지 거짓으로 뜨던 `삭제되었습니다.` 대신 `만족도를 찾을 수 없습니다.` 가 표시됩니다. 이미 404 를 쓰는 댓글·게시글 삭제와 같은 동작입니다.

이미 삭제된 만족도의 재삭제는 이번 범위가 아닙니다. 삭제가 `useAt` 을 `N` 으로 바꾸는 소프트 삭제라(`EgovStsfdgServiceImpl.java:115`) 행이 남아 `findById` 가 값을 돌려주고 위 분기에 닿지 않습니다. 게시글 삭제가 가진 `useAt` 검사(`EgovBoardServiceImpl.java:369-371`)를 만족도에 들이는 것은 별개 수정이라 섞지 않았습니다.

`EgovStsfdgService.java:13` 의 `int` 반환 시그니처는 그대로 두었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

먼저 임시 프로브로 응답코드를 찍어 확인했습니다. 실제 `EgovStsfdgServiceImpl` 과 비어 있는 저장소를 컨트롤러에 물린 프로브입니다.

수정 전

```
PROBE deleteStsfdg(존재하지 않는 번호) -> status=200
PROBE deleteComment(존재하지 않는 댓글) -> status=404
```

수정 후

```
PROBE deleteStsfdg(존재하지 않는 번호) -> status=404
PROBE deleteComment(존재하지 않는 댓글) -> status=404
```

프로브는 커밋하지 않았습니다. 대신 두 계층을 각각 고정하는 테스트를 넣었습니다. `EgovStsfdgServiceImplTest.deleteStsfdgThrowsWhenRowMissing` 은 저장소가 비었을 때 서비스가 던지는지 확인합니다. `EgovCommentAPIControllerTest.deleteStsfdgReturnsNotFoundWhenRowMissing` 은 서비스가 던졌을 때 컨트롤러가 404 로 바꾸는지 확인합니다.

```
mvn test -Dtest='EgovStsfdgServiceImplTest,EgovCommentAPIControllerTest'
```

프로덕션 수정 없이 테스트만 올려 두면 두 건이 실패합니다. 컨트롤러 테스트는 서비스를 mock 하므로 예외 자체는 던져지고 매핑이 없어 그대로 밖으로 나갑니다.

```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   EgovStsfdgServiceImplTest.deleteStsfdgThrowsWhenRowMissing:37 
Expecting code to raise a throwable.
[ERROR] Errors: 
[ERROR]   EgovCommentAPIControllerTest.deleteStsfdgReturnsNotFoundWhenRowMissing:85 » Servlet Request processing failed: java.lang.IllegalStateException: 만족도를 찾을 수 없습니다.
[INFO] 
[ERROR] Tests run: 3, Failures: 1, Errors: 1, Skipped: 0
```

수정을 적용하면 통과합니다.

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

EgovBoard 모듈 전체(`mvn test`)도 통과합니다.

```
[INFO] Results:
[INFO] 
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

API 응답코드 수정이라 브라우저 테스트는 하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 파일 변경이 없어 위 「JUnit 테스트」 절의 출력으로 대신합니다.
