### PR TITLE
fix(EgovBoard): 만족도 점수를 0점에서 5점으로 제한

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/StsfdgVO.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/StsfdgVO.java
@@ -1,6 +1,8 @@
 package egovframework.com.cop.brd.service;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +26,8 @@ public class StsfdgVO extends EgovDefaultVO implements Serializable {
     private String password = "";
     @EgovNullCheck(message = "{comCopBbs.boardMasterVO.detail.option2}{common.required.msg}")
     private String stsfdgCn = "";
+    @Min(value = 0, message = "만족도는 0점 이상이어야 합니다.")
+    @Max(value = 5, message = "만족도는 5점 이하여야 합니다.")
     private int stsfdg = 0;
     private String useAt = "";
     private String frstRegisterId = "";

--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/web/EgovCommentAPIController.java
@@ -152,12 +152,10 @@ public class EgovCommentAPIController {
                 errors.put(error.getField(), error.getDefaultMessage());
             }
             return ResponseEntity.badRequest().body(errors);
-        } else {
-            if (stsfdgVO.getStsfdg() >= 0) {
-                Map<String, String> userInfo = extracted(request);
-                bbsStsfdgService.insertStsfdg(stsfdgVO, userInfo);
-            }
         }
+
+        Map<String, String> userInfo = extracted(request);
+        bbsStsfdgService.insertStsfdg(stsfdgVO, userInfo);
 
         return ResponseEntity.ok().body("등록이 완료되었습니다.");
     }

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentAPIControllerTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/web/EgovCommentAPIControllerTest.java
@@ -3,6 +3,7 @@ package egovframework.com.cop.brd.web;
 import egovframework.com.cop.brd.service.CommentVO;
 import egovframework.com.cop.brd.service.EgovCommentService;
 import egovframework.com.cop.brd.service.EgovStsfdgService;
+import egovframework.com.cop.brd.service.StsfdgVO;
 import egovframework.com.pagination.EgovKrdsPaginationRenderer;
 import org.egovframe.boot.crypto.service.EgovEnvCryptoService;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -73,5 +75,46 @@ class EgovCommentAPIControllerTest {
         assertThat(comment.getNttId()).isEqualTo(1L);
         assertThat(comment.getAnswerNo()).isEqualTo(1L);
         assertThat(comment.getAnswer()).isNull();
+    }
+
+    @Test
+    void insertSatisfactionAcceptsFivePoints() throws Exception {
+        when(cryptoService.decrypt(anyString())).thenReturn("test-user");
+
+        mockMvc.perform(post("/cop/brd/insertStsfdg")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-USER-ID", "encrypted-user-id")
+                        .header("X-USER-NM", "encrypted-user-name")
+                        .header("X-UNIQ-ID", "encrypted-uniq-id")
+                        .content("""
+                                {
+                                  "bbsId": "BBSMSTR_000000000001",
+                                  "nttId": 1,
+                                  "stsfdgCn": "만족합니다.",
+                                  "stsfdg": 5
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<StsfdgVO> satisfactionCaptor = ArgumentCaptor.forClass(StsfdgVO.class);
+        verify(stsfdgService).insertStsfdg(satisfactionCaptor.capture(), anyMap());
+        assertThat(satisfactionCaptor.getValue().getStsfdg()).isEqualTo(5);
+    }
+
+    @Test
+    void insertSatisfactionRejectsMoreThanFivePoints() throws Exception {
+        mockMvc.perform(post("/cop/brd/insertStsfdg")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "bbsId": "BBSMSTR_000000000001",
+                                  "nttId": 1,
+                                  "stsfdgCn": "범위를 벗어난 점수",
+                                  "stsfdg": 6
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(stsfdgService);
     }
 }


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

만족도 등록 API에서 점수의 최댓값을 검사하지 않아 5점을 초과하는 값도 등록할 수 있었습니다.

`StsfdgVO`의 만족도 점수에 `@Min(0)`과 `@Max(5)` 검증을 추가했습니다. 유효하지 않은 요청은 HTTP 400 응답으로 처리되며, 만족도 등록 서비스는 호출되지 않습니다.

컨트롤러에서는 검증을 통과한 요청만 등록 처리하도록 기존 조건문을 정리했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

실행 결과:

- `EgovCommentAPIControllerTest`
- 5점 요청 등록 성공 확인
- 6점 요청 HTTP 400 응답 확인
- 잘못된 요청에서 만족도 등록 서비스가 호출되지 않는 것 확인
- EgovBoard 전체 테스트 9개 통과

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 코드 수정 후 브라우저 정상 작동 확인

https://github.com/user-attachments/assets/d038d493-6939-48ba-ab04-68b0df8ff177


### 5점 이상 요청 테스트

https://github.com/user-attachments/assets/98668523-56a0-4fa1-9934-b79fff9675fe


### JUnit Test 결과

<img width="1488" height="490" alt="image" src="https://github.com/user-attachments/assets/01f1a950-ee0c-4ec4-b124-162ad55a40d3" />


