### PR TITLE
build(config-server): 부모 POM 업데이트 및 의존성 버전 관리 정리

### DIFF
--- a/ConfigServer/pom.xml
+++ b/ConfigServer/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>egovframework</groupId>
     <artifactId>ConfigServer</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.3</version>
     <name>ConfigServer</name>
     <url>https://www.egovframe.go.kr</url>
 
@@ -19,18 +19,14 @@
     <parent>
         <groupId>org.egovframe.boot</groupId>
         <artifactId>egovframe-boot-starter-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1</version>
         <relativePath/>
     </parent>
 
     <properties>
         <java.version>17</java.version>
         <logback.version>1.5.32</logback.version>
-        <log4j2.version>2.25.3</log4j2.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <tomcat-embed.version>10.1.52</tomcat-embed.version>
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <tomcat.version>10.1.52</tomcat.version>
         <commons-configuration2.version>2.11.0</commons-configuration2.version>
     </properties>
 
@@ -85,72 +81,59 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <!-- Logging -->
         <!-- CVE-2025-68161: 취약점 보완용 업데이트 -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <!-- CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-annotations-api</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <!-- CVE-2025-48734: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
         </dependency>
         <!-- CVE-2025-48924: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <!-- CVE-2025-46392: 보안취약점 보완용 직접 주입 -->
         <dependency>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

ConfigServer의 부모 POM을 업데이트하고 중복된 의존성 버전 선언을 정리합니다.

## 수정된 소스 내용 Modified source

변경 파일: `ConfigServer/pom.xml`

- ConfigServer 버전: `5.0.0` → `5.0.3`
- egovframe-boot-starter-parent 버전: `5.0.0` → `5.0.1`
- Tomcat 버전 속성: `tomcat-embed.version` → `tomcat.version`
  - 설정값 `10.1.52` 유지
- Logback, Log4j2, SLF4J, Tomcat, Commons BeanUtils 및 Commons Lang3의
  개별 `<version>` 선언을 제거하여 상속된 의존성 관리 사용
- Log4j2, SLF4J, Commons BeanUtils 및 Commons Lang3의 버전 속성 제거
- Logback `1.5.32` 속성과 Commons Configuration2 `2.11.0` 명시 설정 유지

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

수행한 검증:
- `git diff --check` 통과
- 지정된 JDK 17.0.17+10 및 Maven 3.9.9 환경에서
  `mvn -o -f ConfigServer/pom.xml validate` 성공

컴파일, JUnit 테스트 및 애플리케이션 실행 검증은 수행하지 않았습니다.
최종 의존성 해석 결과와 실행 호환성은 별도 확인이 필요합니다.

## 테스트 브라우저 Test Browser

해당 없음.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음.

https://youtu.be/1yiRpn7dt_I
