### PR TITLE
fix(EgovBoard): 게시글 목록의 불필요한 댓글 조인 제거

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImpl.java
@@ -90,7 +90,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
         QBbs bbs = QBbs.bbs;
         QUserMaster userMaster = QUserMaster.userMaster;
         QBbsMaster bbsMaster = QBbsMaster.bbsMaster;
-        QComment comment = QComment.comment;
 
         List<Tuple> results = boardListQuery(bbsVO,"notice").fetch();
 
@@ -99,7 +98,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
             Bbs b = tuple.get(bbs);
             UserMaster user =tuple.get(userMaster);
             BbsMaster bm = tuple.get(bbsMaster);
-            Comment c = tuple.get(comment);
 
             String userNm = (user != null && user.getUserNm() != null) ? user.getUserNm() : b.getNtcrNm();
             String bbsNm = bm != null && bm.getBbsNm() != null ? bm.getBbsNm() : "";
@@ -143,7 +141,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
         QBbs bbs = QBbs.bbs;
         QUserMaster userMaster = QUserMaster.userMaster;
         QBbsMaster bbsMaster = QBbsMaster.bbsMaster;
-        QComment comment = QComment.comment;
 
         BooleanBuilder where = new BooleanBuilder();
         if ("1".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
@@ -167,9 +164,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
                         .on(bbs.frstRegisterId.eq(userMaster.esntlId))
                         .leftJoin(bbsMaster)
                         .on(bbs.bbsId.bbsId.eq(bbsMaster.bbsId))
-                        .leftJoin(comment)
-                        .on(bbs.bbsId.nttId.eq(comment.commentId.nttId)
-                                .and(bbs.bbsId.bbsId.eq(comment.commentId.bbsId)))
                         .where(bbs.bbsId.bbsId.eq(bbsVO.getBbsId())
                                 .and(bbs.useAt.eq("Y")).and(bbs.noticeAt.isNull())
                                 .and(where))
@@ -181,7 +175,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
             Bbs b = tuple.get(bbs);
             UserMaster user =tuple.get(userMaster);
             BbsMaster bm = tuple.get(bbsMaster);
-            Comment c = tuple.get(comment);
 
             String userNm = (user != null && user.getUserNm() != null) ? user.getUserNm() : b.getNtcrNm();
             String bbsNm = bm != null && bm.getBbsNm() != null ? bm.getBbsNm() : "";
@@ -570,7 +563,6 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
         QBbs bbs = QBbs.bbs;
         QUserMaster userMaster = QUserMaster.userMaster;
         QBbsMaster bbsMaster = QBbsMaster.bbsMaster;
-        QComment comment = QComment.comment;
 
         BooleanBuilder where = new BooleanBuilder();
         if ("1".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
@@ -588,15 +580,12 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
         }
 
         return queryFactory
-                .select(bbs, userMaster, bbsMaster, comment)
+                .select(bbs, userMaster, bbsMaster)
                 .from(bbs)
                 .leftJoin(userMaster)
                 .on(bbs.frstRegisterId.eq(userMaster.esntlId))
                 .leftJoin(bbsMaster)
                 .on(bbs.bbsId.bbsId.eq(bbsMaster.bbsId))
-                .leftJoin(comment)
-                .on(bbs.bbsId.nttId.eq(comment.commentId.nttId)
-                        .and(bbs.bbsId.bbsId.eq(comment.commentId.bbsId)))
                 .where(bbs.bbsId.bbsId.eq(bbsVO.getBbsId())
                         .and(where))
                 .orderBy(bbs.sortOrdr.desc(), bbs.parntscttNo.asc(), bbs.answerLc.asc(), bbs.nttNo.asc(), bbs.frstRegistPnttm.desc());

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovBoardListIntegrationTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovBoardListIntegrationTest.java
@@ -1,0 +1,60 @@
+package egovframework.com.cop.brd.service.impl;
+
+import egovframework.com.cop.brd.service.BbsVO;
+import egovframework.com.cop.brd.service.BoardDTO;
+import egovframework.com.cop.brd.service.EgovBoardService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class EgovBoardListIntegrationTest {
+
+    @Autowired
+    private EgovBoardService service;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void listDoesNotDuplicateBoardWithMultipleComments() {
+        String bbsId = "BBS_TEST_DUPLICATE";
+        long nttId = 999999998L;
+        String userId = "TEST_USER";
+        jdbcTemplate.update("INSERT INTO COMTNBBSMASTER "
+                + "(BBS_ID, BBS_NM, BBS_TY_CODE, FILE_ATCH_POSBL_AT, ATCH_POSBL_FILE_NUMBER, "
+                + "USE_AT, FRST_REGISTER_ID, FRST_REGIST_PNTTM) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, NOW())",
+                bbsId, "중복 검증 게시판", "BBST01", "N", 0, "Y", userId);
+        jdbcTemplate.update("INSERT INTO COMTNBBS "
+                + "(NTT_ID, BBS_ID, NTT_NO, NTT_SJ, NTT_CN, USE_AT, FRST_REGISTER_ID, FRST_REGIST_PNTTM) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, NOW())",
+                nttId, bbsId, 1, "댓글 조인 중복 검증", "테스트 내용", "Y", userId);
+        jdbcTemplate.update("INSERT INTO COMTNCOMMENT "
+                + "(NTT_ID, BBS_ID, ANSWER_NO, ANSWER, USE_AT, FRST_REGISTER_ID, FRST_REGIST_PNTTM) "
+                + "VALUES (?, ?, ?, ?, ?, ?, NOW()), (?, ?, ?, ?, ?, ?, NOW())",
+                nttId, bbsId, 1, "첫 번째 댓글", "Y", userId,
+                nttId, bbsId, 2, "두 번째 댓글", "Y", userId);
+
+        BbsVO vo = new BbsVO();
+        vo.setBbsId(bbsId);
+        vo.setPageIndex(1);
+        vo.setFirstIndex(0);
+        vo.setPageUnit(10);
+
+        Map<String, Object> result = service.list(vo);
+
+        @SuppressWarnings("unchecked")
+        List<BoardDTO> content = (List<BoardDTO>) result.get("content");
+        assertThat(content).extracting(BoardDTO::getNttId).containsExactly(nttId);
+        assertThat(result.get("totalElements")).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시글 목록 조회에서 사용하지 않는 댓글 테이블 조인을 제거했습니다.

기존 쿼리는 게시글과 댓글을 일대다로 조인하고 있어, 댓글이 여러 개인 게시글이 댓글 수만큼 목록에 중복으로 포함될 수 있었습니다.

목록 응답에서 댓글 정보는 사용하지 않으므로 관련 조인과 조회 항목을 제거했습니다. 게시글 목록과 전체 건수가 댓글 수의 영향을 받지 않도록 수정했습니다.

여러 댓글이 등록된 게시글도 목록에서 한 건으로 조회되는지 확인하는 통합 테스트를 추가했습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 테스트 결과

- `EgovBoardListIntegrationTest`
- 테스트 1건 통과
- 댓글이 2개인 게시글의 목록 건수와 전체 건수가 각각 1건인지 확인
- 브라우저에서 댓글이 여러 개인 게시글이 목록에 한 번만 표시되는지 확인

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

댓글이 여러 개인 게시글이 목록에 중복으로 표시되는 화면

<img width="1727" height="568" alt="image" src="https://github.com/user-attachments/assets/ed8ded52-70c7-43d0-8e30-dc105e1a545b" />

### 수정 후

동일한 게시글이 목록에 한 번만 표시되는 화면

<img width="1730" height="561" alt="image" src="https://github.com/user-attachments/assets/da60aed7-988b-4067-a348-a03d28590e41" />


### Junit

<img width="1456" height="486" alt="image" src="https://github.com/user-attachments/assets/6efaba4f-e95f-4a59-9057-9c4853a92ceb" />

