### PR TITLE
fix(EgovQuestionnaire): 설문 응답 코드 조인 별칭 분리

### DIFF
--- a/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qrm/service/impl/EgovQustnrRespondInfoServiceImpl.java
+++ b/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qrm/service/impl/EgovQustnrRespondInfoServiceImpl.java
@@ -55,8 +55,8 @@ public class EgovQustnrRespondInfoServiceImpl extends EgovAbstractServiceImpl im
         QQustnrRespondInfo qustnrRespondInfo = QQustnrRespondInfo.qustnrRespondInfo;
         QUserMaster userMaster = QUserMaster.userMaster;
         QQestnrInfo qestnrInfo = QQestnrInfo.qestnrInfo;
-        QCmmnDetailCode sexCode = QCmmnDetailCode.cmmnDetailCode;
-        QCmmnDetailCode tyCode = QCmmnDetailCode.cmmnDetailCode;
+        QCmmnDetailCode sexCode = new QCmmnDetailCode("sexCode");
+        QCmmnDetailCode tyCode = new QCmmnDetailCode("tyCode");
 
         BooleanBuilder where = new BooleanBuilder();
         if ("1".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
@@ -65,7 +65,7 @@ public class EgovQustnrRespondInfoServiceImpl extends EgovAbstractServiceImpl im
             where.and(userMaster.userNm.contains(searchKeyword));
         }
 
-        List<Tuple> results = qustnrRespondInfoQuery()
+        List<Tuple> results = qustnrRespondInfoQuery(sexCode, tyCode)
                 .where(where)
                 .orderBy(qustnrRespondInfo.frstRegistPnttm.desc())
                 .offset(pageable.getOffset())
@@ -137,10 +137,10 @@ public class EgovQustnrRespondInfoServiceImpl extends EgovAbstractServiceImpl im
         QQustnrRespondInfo qustnrRespondInfo = QQustnrRespondInfo.qustnrRespondInfo;
         QUserMaster userMaster = QUserMaster.userMaster;
         QQestnrInfo qestnrInfo = QQestnrInfo.qestnrInfo;
-        QCmmnDetailCode sexCode = QCmmnDetailCode.cmmnDetailCode;
-        QCmmnDetailCode tyCode = QCmmnDetailCode.cmmnDetailCode;
+        QCmmnDetailCode sexCode = new QCmmnDetailCode("sexCode");
+        QCmmnDetailCode tyCode = new QCmmnDetailCode("tyCode");
 
-        Tuple tuple = qustnrRespondInfoQuery()
+        Tuple tuple = qustnrRespondInfoQuery(sexCode, tyCode)
                 .where(qustnrRespondInfo.qustnrRespondInfoId.qustnrRespondId.eq(qustnrRespondInfoVO.getQustnrRespondId()))
                 .fetchOne();
 
@@ -249,12 +249,10 @@ public class EgovQustnrRespondInfoServiceImpl extends EgovAbstractServiceImpl im
         }
     }
 
-    private JPAQuery<Tuple> qustnrRespondInfoQuery(){
+    private JPAQuery<Tuple> qustnrRespondInfoQuery(QCmmnDetailCode sexCode, QCmmnDetailCode tyCode){
         QQustnrRespondInfo qustnrRespondInfo = QQustnrRespondInfo.qustnrRespondInfo;
         QUserMaster userMaster = QUserMaster.userMaster;
         QQestnrInfo qestnrInfo = QQestnrInfo.qestnrInfo;
-        QCmmnDetailCode sexCode = QCmmnDetailCode.cmmnDetailCode;
-        QCmmnDetailCode tyCode = QCmmnDetailCode.cmmnDetailCode;
 
         return queryFactory
                 .select(qustnrRespondInfo,userMaster,qestnrInfo,sexCode,tyCode)

--- a/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qrm/service/impl/EgovQustnrRespondInfoServiceImplTest.java
+++ b/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qrm/service/impl/EgovQustnrRespondInfoServiceImplTest.java
@@ -1,0 +1,55 @@
+package egovframework.com.uss.olp.qrm.service.impl;
+
+import egovframework.com.uss.olp.qrm.service.EgovQustnrRespondInfoService;
+import egovframework.com.uss.olp.qrm.service.QustnrRespondInfoDTO;
+import egovframework.com.uss.olp.qrm.service.QustnrRespondInfoVO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class EgovQustnrRespondInfoServiceImplTest {
+
+    @Autowired
+    private EgovQustnrRespondInfoService service;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void listReturnsSeparateSexAndOccupationCodeNames() {
+        String templateId = "TEST_CODE_ALIAS";
+        String questionnaireId = "TEST_CODE_ALIAS";
+        String respondentId = "TEST_CODE_ALIAS";
+        jdbcTemplate.update("INSERT INTO COMTNQUSTNRTMPLAT "
+                + "(QUSTNR_TMPLAT_ID, QUSTNR_TMPLAT_TY) VALUES (?, ?)", templateId, "1");
+        jdbcTemplate.update("INSERT INTO COMTNQESTNRINFO "
+                + "(QUSTNR_TMPLAT_ID, QESTNR_ID, QUSTNR_SJ) VALUES (?, ?, ?)",
+                templateId, questionnaireId, "별칭 검증 설문");
+        jdbcTemplate.update("INSERT INTO COMTNQUSTNRRESPONDINFO "
+                + "(QUSTNR_TMPLAT_ID, QESTNR_ID, QUSTNR_RESPOND_ID, SEXDSTN_CODE, OCCP_TY_CODE, "
+                + "RESPOND_NM, FRST_REGIST_PNTTM, LAST_UPDT_PNTTM) "
+                + "VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())",
+                templateId, questionnaireId, respondentId, "M", "1", "별칭 검증 응답자");
+
+        QustnrRespondInfoVO vo = new QustnrRespondInfoVO();
+        vo.setFirstIndex(0);
+        vo.setRecordCountPerPage(10);
+
+        Page<QustnrRespondInfoDTO> result = service.list(vo);
+
+        assertThat(result.getContent())
+                .filteredOn(item -> respondentId.equals(item.getQustnrRespondId()))
+                .singleElement()
+                .satisfies(item -> {
+                    assertThat(item.getSexdstnNm()).isEqualTo("남자");
+                    assertThat(item.getOccpTyNm()).isEqualTo("학생");
+                });
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

설문 응답 목록과 상세 조회에서 성별 코드와 직업 코드가 같은 QueryDSL 별칭을 사용하고 있었습니다.

두 공통 코드 테이블을 구분하지 못해 직업명이 성별명과 동일하게 표시되는 문제를 수정했습니다.

## 수정된 소스 내용 Modified source

- 성별 코드와 직업 코드에 각각 `sexCode`, `tyCode` 별칭 적용
- 조회 쿼리와 결과 매핑에서 동일한 별칭 인스턴스를 사용하도록 변경
- 성별명과 직업명이 각각 올바르게 조회되는지 확인하는 테스트 추가

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

실행한 테스트:

- `EgovQustnrRespondInfoServiceImplTest`
- `listReturnsSeparateSexAndOccupationCodeNames()`
- 성별 코드 `M`이 `남자`로 조회되는지 확인
- 직업 코드 `1`이 `학생`으로 조회되는지 확인

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

<img width="663" height="450" alt="image" src="https://github.com/user-attachments/assets/a44c8c16-1b0a-48c6-a474-aa982e67091e" />


### 수정 후

<img width="420" height="320" alt="image" src="https://github.com/user-attachments/assets/170f0e9a-2a4a-4f1d-b2b1-c3ba4698d470" />


### JUnit 테스트

<img width="1427" height="478" alt="image" src="https://github.com/user-attachments/assets/3c875637-2284-452d-825e-6f3438d702d2" />
