### PR TITLE
fix(EgovQuestionnaire): 설문 응답 항목 필수 검증 추가

### DIFF
--- a/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qri/service/QustnrRspnsResultVO.java
+++ b/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qri/service/QustnrRspnsResultVO.java
@@ -1,5 +1,6 @@
 package egovframework.com.uss.olp.qri.service;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,6 +34,7 @@ public class QustnrRspnsResultVO extends EgovDefaultVO implements Serializable {
     @EgovNullCheck(message="{comUssOlpQri.regist.respondNm}{common.required.msg}")
     private String respondNm;
 
+    @NotEmpty(message="{comUssOlpQri.regist.qustnrIem}{common.required.msg}")
     private String[] qustnrItemList;
 
     private String frstRegistPnttm;

--- a/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qri/service/QustnrRspnsResultVOTest.java
+++ b/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qri/service/QustnrRspnsResultVOTest.java
@@ -1,0 +1,23 @@
+package egovframework.com.uss.olp.qri.service;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QustnrRspnsResultVOTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void qustnrItemListIsRequired() {
+        QustnrRspnsResultVO vo = new QustnrRspnsResultVO();
+
+        assertThat(validator.validateProperty(vo, "qustnrItemList")).isNotEmpty();
+
+        vo.setQustnrItemList(new String[0]);
+
+        assertThat(validator.validateProperty(vo, "qustnrItemList")).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

설문 응답 등록 요청에서 응답 항목 목록이 누락되면 서비스 처리 과정에서 오류가 발생해 HTTP 500 응답이 반환됐습니다.

`QustnrRspnsResultVO`의 `qustnrItemList` 필드에 `@NotEmpty` 검증을 추가했습니다.

응답 항목이 없거나 빈 배열로 전달되면 서비스 로직에 진입하기 전에 입력값 오류로 처리되며, `qustnrItemList`에 대한 검증 메시지가 반환됩니다.

검증 동작을 확인할 수 있도록 `QustnrRspnsResultVOTest`를 추가했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 테스트 결과

- `QustnrRspnsResultVOTest` 1건 통과
- 응답 항목을 제외한 설문 제출 요청으로 수정 전·후 동작 비교
- 수정 전: HTTP 500 응답
- 수정 후: HTTP 200 응답과 함께 `qustnrItemList` 입력값 검증 오류 반환

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

응답 항목이 누락된 요청에서 HTTP 500 응답이 발생하는 개발자 도구 화면

<img width="661" height="256" alt="image" src="https://github.com/user-attachments/assets/21b4f43a-a2ec-4ef0-86d8-dc4a51631383" />


### 수정 후

동일한 요청에서 HTTP 200 응답과 `qustnrItemList` 검증 오류가 반환되는 개발자 도구 화면

<img width="656" height="265" alt="image" src="https://github.com/user-attachments/assets/384d5b74-6653-4f25-9532-8c4e918facad" />


### Junit

<img width="1453" height="485" alt="image" src="https://github.com/user-attachments/assets/451254c5-8ca2-4a35-93b4-c088dae7be52" />
