### PR TITLE
fix(EgovQuestionnaire): 주관식 답변의 쉼표 보존

### DIFF
--- a/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qri/service/impl/EgovQustnrRspnsResultServiceImpl.java
+++ b/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qri/service/impl/EgovQustnrRspnsResultServiceImpl.java
@@ -166,7 +166,7 @@ public class EgovQustnrRspnsResultServiceImpl extends EgovAbstractServiceImpl im
             // 설문조사 저장
             String[] itemArray = qustnrRspnsResultVO.getQustnrItemList();
             for (String item : itemArray) {
-                String[] itemList = item.split(",");
+                String[] itemList = item.split(",", 3);
                 if ("1".equals(itemList[0])) {
                     qustnrRspnsResultVO.setQustnrRspnsResultId(idgenService.getNextStringId());
                     qustnrRspnsResultVO.setQustnrQesitmId(itemList[1]);

--- a/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qri/service/impl/EgovQustnrRspnsResultServiceImplTest.java
+++ b/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qri/service/impl/EgovQustnrRspnsResultServiceImplTest.java
@@ -1,0 +1,63 @@
+package egovframework.com.uss.olp.qri.service.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import egovframework.com.uss.olp.qri.entity.QustnrRspnsResult;
+import egovframework.com.uss.olp.qri.repository.EgovQestnrInfoRepository;
+import egovframework.com.uss.olp.qri.repository.EgovQustnrRespondInfoRepository;
+import egovframework.com.uss.olp.qri.repository.EgovQustnrRspnsResultRepository;
+import egovframework.com.uss.olp.qri.service.QustnrRspnsResultVO;
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EgovQustnrRspnsResultServiceImplTest {
+
+    @Mock
+    private EgovQustnrRspnsResultRepository repository;
+    @Mock
+    private EgovQustnrRespondInfoRepository qustnrRespondInfoRepository;
+    @Mock
+    private EgovQestnrInfoRepository qestnrInfoRepository;
+    @Mock
+    private EgovIdGnrService idgenService;
+    @Mock
+    private EgovIdGnrService qustnrRespondInfoIdgenService;
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @Test
+    void insertPreservesCommaInEssayAnswer() throws Exception {
+        EgovQustnrRspnsResultServiceImpl service = new EgovQustnrRspnsResultServiceImpl(
+                repository,
+                qustnrRespondInfoRepository,
+                qestnrInfoRepository,
+                idgenService,
+                qustnrRespondInfoIdgenService,
+                queryFactory
+        );
+        QustnrRspnsResultVO request = new QustnrRspnsResultVO();
+        request.setQustnrTmplatId("TMPLAT_1");
+        request.setQestnrId("QESTNR_1");
+        request.setQustnrItemList(new String[]{"2,QESITM_1,좋음, 보통"});
+
+        when(qustnrRespondInfoIdgenService.getNextStringId()).thenReturn("RESPOND_1");
+        when(idgenService.getNextStringId()).thenReturn("RESULT_1");
+
+        boolean result = service.insert(request, Map.of("uniqId", "USER_1"));
+
+        ArgumentCaptor<QustnrRspnsResult> captor = ArgumentCaptor.forClass(QustnrRspnsResult.class);
+        verify(repository).save(captor.capture());
+        assertThat(result).isTrue();
+        assertThat(captor.getValue().getRespondAnswerCn()).isEqualTo("좋음, 보통");
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

설문 주관식 답변에 쉼표가 포함되면 쉼표 뒤의 내용이 유실되는 문제를 수정했습니다.

응답 항목을 쉼표로 분리할 때 최대 분리 개수를 지정하여, 설문 식별값을 제외한 나머지 문자열이 주관식 답변으로 보존되도록 변경했습니다.

예를 들어 `좋음, 보통`을 입력한 경우 기존에는 `좋음`만 저장됐지만, 수정 후에는 `좋음, 보통` 전체가 저장됩니다.

해당 동작을 확인할 수 있도록 `EgovQustnrRspnsResultServiceImplTest`를 추가했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 테스트 결과

- `EgovQustnrRspnsResultServiceImplTest` 1건 통과
- 동일한 설문에 `좋음, 보통`을 입력해 수정 전·후 저장 결과 비교
- 수정 전: `좋음`으로 저장되어 쉼표 뒤 내용 유실
- 수정 후: `좋음, 보통` 전체 저장
- 설문 통계 화면에서 저장된 답변이 그대로 표시되는지 확인

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

`좋음, 보통`을 입력했지만 설문 통계에 `좋음`만 표시됨

<img width="636" height="517" alt="image" src="https://github.com/user-attachments/assets/aca970df-7cd9-4356-8788-25eead087702" />


### 수정 후

동일한 답변을 새로 등록한 뒤 설문 통계에 `좋음, 보통` 전체가 표시됨

<img width="643" height="558" alt="image" src="https://github.com/user-attachments/assets/071258c3-e1bb-4ad0-a12f-614ff082cf4f" />


### Junit

<img width="1456" height="492" alt="image" src="https://github.com/user-attachments/assets/74600241-a94b-4891-b911-bf75068dcc9c" />
