### PR TITLE
fix(EgovAuthor): 권한 그룹 검색 건수에 조건 적용

### DIFF
--- a/EgovAuthor/src/main/java/egovframework/com/sec/rgm/service/impl/EgovAuthorGroupServiceImpl.java
+++ b/EgovAuthor/src/main/java/egovframework/com/sec/rgm/service/impl/EgovAuthorGroupServiceImpl.java
@@ -97,6 +97,7 @@ public class EgovAuthorGroupServiceImpl extends EgovAbstractServiceImpl implemen
                                 .and(code.cmmnDetailCodeId.codeId.eq("COM012"))
                                 .and(code.useAt.eq("Y"))
                 )
+                .where(where)
                 .fetchOne()
         ).orElse(0L);
 

--- a/EgovAuthor/src/test/java/egovframework/com/sec/rgm/service/impl/EgovAuthorGroupServiceImplTest.java
+++ b/EgovAuthor/src/test/java/egovframework/com/sec/rgm/service/impl/EgovAuthorGroupServiceImplTest.java
@@ -1,0 +1,32 @@
+package egovframework.com.sec.rgm.service.impl;
+
+import egovframework.com.sec.rgm.service.AuthorGroupDTO;
+import egovframework.com.sec.rgm.service.AuthorGroupVO;
+import egovframework.com.sec.rgm.service.EgovAuthorGroupService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class EgovAuthorGroupServiceImplTest {
+
+    @Autowired
+    private EgovAuthorGroupService service;
+
+    @Test
+    void listAppliesSearchConditionToTotalCount() {
+        AuthorGroupVO authorGroupVO = new AuthorGroupVO();
+        authorGroupVO.setFirstIndex(0);
+        authorGroupVO.setRecordCountPerPage(10);
+        authorGroupVO.setSearchCondition("1");
+        authorGroupVO.setSearchKeyword("__NON_EXISTENT_USER_ID__");
+
+        Page<AuthorGroupDTO> result = service.list(authorGroupVO);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

권한 그룹 목록을 검색할 때 목록 조회에는 검색 조건이 적용되지만, 전체 건수 조회에는 검색 조건이 적용되지 않는 문제를 수정했습니다.

전체 건수 조회 쿼리에도 목록 조회와 동일한 `where` 조건을 적용했습니다. 이에 따라 검색 결과의 실제 건수와 페이지 수가 같은 조건을 기준으로 계산됩니다.

해당 동작을 확인할 수 있도록 `EgovAuthorGroupServiceImplTest`를 추가했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

### 테스트 결과

- `EgovAuthorGroupServiceImplTest` 1건 통과
- 전체 사용자가 14명인 상태에서 한 명만 일치하는 사용자 ID로 검색
- 수정 전: 검색 결과는 1건이지만 페이지 번호 `1`, `2` 노출
- 수정 후: 검색 결과와 전체 건수가 모두 1건으로 계산되어 페이지 번호 `1`만 노출

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

검색 결과가 1건이지만 검색 조건이 반영되지 않은 전체 건수 때문에 페이지 번호 `1`, `2`가 표시

<img width="887" height="362" alt="image" src="https://github.com/user-attachments/assets/47a28201-c6e3-4743-b656-ab530e3a060d" />


### 수정 후

동일한 검색 조건에서 전체 건수가 1건으로 계산되고 페이지 번호 `1`만 표시

<img width="894" height="370" alt="image" src="https://github.com/user-attachments/assets/8b4c33a4-94fd-4eb0-955f-daeac949e154" />


### Junit

<img width="1231" height="521" alt="image" src="https://github.com/user-attachments/assets/f6d9e37f-0dc3-44d4-ae4c-5ce74f3ccbbf" />


