### PR TITLE
fix(EgovBoard): 빈 게시기간 표시 개선

### DIFF
--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/brd/boardDetail.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/brd/boardDetail.html
@@ -116,7 +116,12 @@
                 $('#rdcnt').text(response.result.rdcnt);
                 const nttCnElement = document.getElementById('nttCn');
                 nttCnElement.textContent = response.result.nttCn != null ? response.result.nttCn : '';
-                $('#ntceDe').text(response.result.ntceBgnde+' ~ '+response.result.ntceEndde);
+                const ntceBgnde = response.result.ntceBgnde || '';
+                const ntceEndde = response.result.ntceEndde || '';
+                const ntceDe = ntceBgnde && ntceEndde
+                    ? ntceBgnde + ' ~ ' + ntceEndde
+                    : ntceBgnde || ntceEndde || '-';
+                $('#ntceDe').text(ntceDe);
                 renderArticleDetail(response);
                 // 공지사항인 경우 답글 비활성화
                 if (response.result.noticeAt === "Y") {


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시기간이 설정되지 않은 게시글의 상세 화면에서 `null ~ null`이 표시되는 문제를 수정했습니다.

- 시작일과 종료일이 모두 있으면 기존과 같이 `시작일 ~ 종료일`로 표시
- 한쪽 날짜만 있으면 존재하는 날짜만 표시
- 두 날짜가 모두 없으면 `-`로 표시

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전 게시기간이 `null ~ null`로 표시되는 화면

<img width="1278" height="421" alt="image" src="https://github.com/user-attachments/assets/9e2b2825-7e6a-4bc2-9c96-d372fd2aea46" />

수정 후 게시기간이 `-`로 표시되는 화면

<img width="1278" height="399" alt="image" src="https://github.com/user-attachments/assets/30aa123d-718e-4884-8657-8966e0d591b4" />