### PR TITLE
fix(EgovBoard): 커뮤니티 게시판 수정 화면의 불필요한 문자 제거

### DIFF
--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/cmy/bbsMasterUpdate.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/cmy/bbsMasterUpdate.html
@@ -34,7 +34,7 @@
                     <div class="form-conts">
                         <input type="text" id="bbsNm" name="bbsNm" class="krds-input" maxlength="120"
                                th:field="*{bbsNm}"
-                               th:placeholder="#{comCopBbs.boardMasterVO.regist.bbsNm}+' '+#{input.input}">>
+                               th:placeholder="#{comCopBbs.boardMasterVO.regist.bbsNm}+' '+#{input.input}">
                     </div>
                     <p class="form-hint-invalid" id="bbsNmError" style="display:none"></p>
                 </div>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

커뮤니티 게시판 수정 화면의 게시판명 입력 요소 뒤에 불필요한 `>` 문자가 중복으로 작성되어 있었습니다.

중복된 문자를 제거하여 게시판명 입력란 아래에 `>` 문자가 노출되지 않도록 수정했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [x] Chrome
- [ ] Firefox
- [x] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전 게시판명 입력란 아래에 `>` 문자가 표시되는 화면

<img width="1266" height="438" alt="image" src="https://github.com/user-attachments/assets/a5cb3c16-b69d-42a8-be64-30944900d9fb" />


수정 후 불필요한 문자가 제거된 커뮤니티 게시판 수정 화면

<img width="1267" height="386" alt="image" src="https://github.com/user-attachments/assets/5fe54ec9-3c7c-4640-a79f-5562ba2a6076" />
