### PR TITLE
fix(EgovBoard): 게시판 마스터 영문 화면의 협업 브레드크럼 다국어 처리

### DIFF
--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterDetail.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterDetail.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterInsert.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterInsert.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterList.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterList.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}"></li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterUpdate.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bbs/bbsMasterUpdate.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시판 마스터의 목록, 상세, 등록, 수정 화면에서 `협업`으로 고정되어 있던 브레드크럼 문구를 공통 메시지 `comCmm.cop.title`로 변경했습니다.

한국어 화면에서는 `협업`, 영문 화면에서는 `Collaboration`으로 표시됩니다.

변경된 화면은 다음과 같습니다.

- 게시판 마스터 목록
- 게시판 마스터 상세
- 게시판 마스터 등록
- 게시판 마스터 수정

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

별도 JUnit 테스트는 추가하지 않았으며, 기존 EgovBoard 테스트 12건이 통과하는 것을 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

게시판 마스터 목록 화면에서 브레드크럼이 `협업`으로 표시되는 화면

<img width="880" height="356" alt="image" src="https://github.com/user-attachments/assets/582e43d7-2a54-4164-b4a4-c56bd66bbe08" />

게시판 마스터 상세 화면에서 브레드크럼이 `협업`으로 표시되는 화면

<img width="1280" height="1269" alt="수정 전 게시판 마스터 상세 화면" src="https://github.com/user-attachments/assets/c1e5ebd1-7fe8-4de9-bc66-e78fed7ff429" />

게시판 마스터 등록 화면에서 브레드크럼이 `협업`으로 표시되는 화면

<img width="1280" height="1269" alt="수정 전 게시판 마스터 등록 화면" src="https://github.com/user-attachments/assets/12cfa8d6-43df-4cc4-a16c-144bd43be233" />

게시판 마스터 수정 화면에서 브레드크럼이 `협업`으로 표시되는 화면

<img width="1280" height="1269" alt="수정 전 게시판 마스터 수정 화면" src="https://github.com/user-attachments/assets/95dc04fd-39ae-4942-bdfc-c0b8a594e74e" />

### 수정 후

게시판 마스터 목록 화면에서 브레드크럼이 `Collaboration`으로 표시되는 화면

<img width="1280" height="1269" alt="수정 후 게시판 마스터 목록 화면" src="https://github.com/user-attachments/assets/4aba6d01-8b8f-4c85-8a5a-2eb51e2b6875" />

게시판 마스터 상세 화면에서 브레드크럼이 `Collaboration`으로 표시되는 화면

<img width="1280" height="1272" alt="수정 후 게시판 마스터 상세 화면" src="https://github.com/user-attachments/assets/c8089cf8-8a9a-49fc-b068-23dea4ffdce9" />

게시판 마스터 등록 화면에서 브레드크럼이 `Collaboration`으로 표시되는 화면

<img width="1280" height="1272" alt="수정 후 게시판 마스터 등록 화면" src="https://github.com/user-attachments/assets/7e888e86-8e51-4e3c-a764-34dee35e4aa8" />

게시판 마스터 수정 화면에서 브레드크럼이 `Collaboration`으로 표시되는 화면

<img width="1280" height="1272" alt="수정 후 게시판 마스터 수정 화면" src="https://github.com/user-attachments/assets/dd1d86d4-617a-4092-b3f4-cbf821d5d466" />