### PR TITLE
fix(EgovBoard): 블로그 브레드크럼 다국어 처리

### DIFF
--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterDetail.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterDetail.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterInsert.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterInsert.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterList.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterList.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterUpdate.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/bbsMasterUpdate.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogDetail.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogDetail.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogInsert.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogInsert.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogList.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogList.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogUpdate.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/bls/blogUpdate.html
@@ -12,7 +12,7 @@
     <nav class="krds-breadcrumb-wrap" aria-label="브레드크럼" id="breadcrumb">
         <ol class="breadcrumb">
             <li class="home"><a href="/" class="txt">홈</a></li>
-            <li>협업</li>
+            <li th:text="#{comCmm.cop.title}">협업</li>
         </ol>
     </nav>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

블로그 및 블로그 게시판 관리 화면의 브레드크럼에 `협업` 문구가 직접 입력되어 있어 언어 설정을 변경해도 한글로 표시되었습니다.

블로그 관련 8개 화면의 고정 문구를 공통 메시지 코드 `comCmm.cop.title`로 변경했습니다.

- 블로그 목록, 등록, 상세, 수정 화면
- 블로그 게시판 목록, 등록, 상세, 수정 화면
- 한국어 설정에서는 `협업`으로 표시
- 영어 설정에서는 `Collaboration`으로 표시

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

별도 JUnit 테스트는 추가하지 않았습니다. 기존 EgovBoard 테스트 12건의 통과를 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

블로그 화면의 브레드크럼이 언어 설정과 관계없이 `협업`으로 표시되는 화면

<img width="883" height="344" alt="image" src="https://github.com/user-attachments/assets/a6162035-a868-41f5-a37e-9dbd3776e962" />

### 수정 후

영어 설정에서 블로그 화면의 브레드크럼이 `Collaboration`으로 표시되는 화면

<img width="877" height="305" alt="image" src="https://github.com/user-attachments/assets/9419d96d-1200-41a3-842b-921c80a886f4" />