### PR TITLE
fix(EgovCmmnCode): 공통코드 수정 화면 제목 수정

### DIFF
--- a/EgovCmmnCode/src/main/resources/templates/egovframework/com/sym/ccm/cca/cmmnCodeUpdate.html
+++ b/EgovCmmnCode/src/main/resources/templates/egovframework/com/sym/ccm/cca/cmmnCodeUpdate.html
@@ -16,7 +16,7 @@
         </ol>
     </nav>
 
-    <h2 class="heading-large"><span th:text="#{comSymCcmCca.cmmnCodeVO.title}+' '+#{title.create}"></span></h2>
+    <h2 class="heading-large"><span th:text="#{comSymCcmCca.cmmnCodeVO.title}+' '+#{title.update}"></span></h2>
 
     <form id="updateForm" name="updateForm" th:object="${cmmnCodeVO}">
     <input type="hidden" th:id="searchCondition" th:name="searchCondition" th:value="${cmmnCodeVO.searchCondition}"/>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

공통코드 수정 화면의 본문 제목이 `공통코드 등록`으로 표시되는 문제를 수정했습니다.

수정 화면에서 등록 메시지인 `title.create` 대신 수정 메시지인 `title.update`를 사용하도록 변경했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

화면 메시지 코드 변경으로 별도 JUnit 테스트는 추가하지 않았습니다. 기존 `EgovCmmnCode` 모듈 테스트 통과를 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

본문 제목이 `공통코드 등록`으로 표시되는 화면

<img width="1600" height="917" alt="공통코드 수정 화면 제목 수정 전" src="https://github.com/user-attachments/assets/72cbbae1-e55d-4c25-8299-3eadf025b52b" />

### 수정 후

본문 제목이 `공통코드 수정`으로 표시되는 화면

<img width="1600" height="917" alt="공통코드 수정 화면 제목 수정 후" src="https://github.com/user-attachments/assets/4bae73cf-cae9-45ec-86bd-87563a722d75" />