### PR TITLE
fix(EgovQuestionnaire): 설문 통계 조회 오류 안내 추가

### DIFF
--- a/EgovQuestionnaire/src/main/resources/templates/egovframework/com/uss/olp/qri/qustnrRspnsResultStatsPopup.html
+++ b/EgovQuestionnaire/src/main/resources/templates/egovframework/com/uss/olp/qri/qustnrRspnsResultStatsPopup.html
@@ -65,7 +65,12 @@
             },
             body: JSON.stringify(param)
         })
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            return response.json();
+        })
         .then(response => {
             const qestnrInfo = response.qestnrInfo;
             document.getElementById('qustnrSj').textContent = qestnrInfo.qustnrSj;
@@ -132,6 +137,11 @@
                 });
             }
             document.getElementById('qustnrResult').innerHTML = html;
+        })
+        .catch(error => {
+            console.error('Failed to load survey statistics:', error);
+            document.getElementById('qustnrResult').innerHTML =
+                '<p class="text-center">[(#{fail.request.msg})]</p>';
         });
     }
 </script>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

설문 통계 API가 오류를 반환해도 응답을 정상 통계 데이터로 처리하여 내용이 비어 있는 모달이 표시되는 문제를 수정했습니다.

HTTP 응답 상태를 확인한 후 정상 응답만 통계 데이터로 처리하도록 변경했습니다.

통계 조회에 실패하면 빈 화면 대신 요청 실패 안내가 표시됩니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

화면 스크립트 변경으로 별도 JUnit 테스트는 추가하지 않았습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

통계 정보가 비어 있는 모달

<img width="1600" height="1000" alt="설문 통계 조회 오류 처리 전" src="https://github.com/user-attachments/assets/f6b4e391-56eb-48c5-a4b1-f4df375da075" />

### 수정 후

요청 실패 안내가 표시되는 통계 모달

<img width="1271" height="635" alt="image" src="https://github.com/user-attachments/assets/fc240ab0-c3f2-4b33-9509-1f44dd6a5e54" />