### PR TITLE
fix(EgovLoginPolicy): IP 형식 검증 메시지 표시

### DIFF
--- a/EgovLoginPolicy/src/main/resources/templates/egovframework/com/uat/uap/loginPolicyUpdate.html
+++ b/EgovLoginPolicy/src/main/resources/templates/egovframework/com/uat/uap/loginPolicyUpdate.html
@@ -56,7 +56,7 @@
                     <div class="form-conts">
                         <input type="text" id="ipInfo" name="ipInfo" class="krds-input" placeholder="IP 정보">
                     </div>
-                    <p class="ipInfoError" style="display:none"></p>
+                    <p class="ipInfoError" id="ipInfoError" style="display:none"></p>
                 </div>
                 <div class="form-group">
                     <div class="form-tit">
@@ -131,7 +131,7 @@
     }
 
     function loginPolicyInsert() {
-        $('#ipInfoNmError').text('');
+        $('#ipInfoError').text('');
         if (confirm('[(#{common.save.msg})]')) {
             $.ajax({
                 url: '/uat/uap/loginPolicyInsert',
@@ -140,7 +140,7 @@
             }).done(function(response) {
                 if(response.status === 'valid') {
                     $.each(response.errors, function(key, value) {
-                        $('#'+key+'Error').text(value);
+                        $('#'+key+'Error').text(value).css('display', 'block');
                     });
                 } else if (response.status === 'error') {
                     alert('[(#{fail.common.insert})]');
@@ -157,7 +157,7 @@
     }
 
     function loginPolicyUpdate() {
-        $('#ipInfoNmError').text('');
+        $('#ipInfoError').text('');
         if (confirm('[(#{common.update.msg})]')) {
             $.ajax({
                 url: '/uat/uap/loginPolicyUpdate',
@@ -166,7 +166,7 @@
             }).done(function(response) {
                 if(response.status === 'valid') {
                     $.each(response.errors, function(key, value) {
-                        $('#'+key+'Error').text(value);
+                        $('#'+key+'Error').text(value).css('display', 'block');
                     });
                 } else if (response.status === 'error') {
                     alert('[(#{fail.common.update})]');


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

로그인정책 등록 및 수정 화면에서 잘못된 IP를 입력해도 형식 오류 메시지가 표시되지 않는 문제를 수정했습니다.

오류 메시지 요소의 ID와 초기화 선택자를 일치시키고, 검증 오류가 발생하면 해당 메시지가 화면에 표시되도록 변경했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

화면 스크립트 변경으로 별도 JUnit 테스트는 추가하지 않았습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

잘못된 IP를 입력해도 오류 메시지가 표시되지 않는 화면

<img width="384" height="615" alt="image" src="https://github.com/user-attachments/assets/1d6996a1-9335-4ae5-bfc0-a407ff41eaee" />

### 수정 후

IP 입력란 아래에 형식 오류 메시지가 표시되는 화면

<img width="381" height="502" alt="image" src="https://github.com/user-attachments/assets/2c3737a2-8eb1-4414-8f1a-09da01aa7107" />
