### PR TITLE
fix(EgovQuestionnaire): 설문 수정 기간 표시 및 저장 형식 보정

### DIFF
--- a/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qmc/service/impl/EgovQestnrInfoServiceImpl.java
+++ b/EgovQuestionnaire/src/main/java/egovframework/com/uss/olp/qmc/service/impl/EgovQestnrInfoServiceImpl.java
@@ -279,8 +279,8 @@ public class EgovQestnrInfoServiceImpl extends EgovAbstractServiceImpl implement
         qestnrInfo.setQustnrPurps(qestnrInfoVO.getQustnrPurps());
         qestnrInfo.setQustnrWritingGuidanceCn(qestnrInfoVO.getQustnrWritingGuidanceCn());
         qestnrInfo.setQustnrTrget(qestnrInfoVO.getQustnrTrget());
-        qestnrInfo.setQustnrBgnde(qestnrInfoVO.getQustnrBgnde());
-        qestnrInfo.setQustnrEndde(qestnrInfoVO.getQustnrEndde());
+        qestnrInfo.setQustnrBgnde(qestnrInfoVO.getQustnrBgnde().replace("-", ""));
+        qestnrInfo.setQustnrEndde(qestnrInfoVO.getQustnrEndde().replace("-", ""));
         qestnrInfo.setLastUpdtPnttm(LocalDateTime.now());
         qestnrInfo.setLastUpdusrId(uniqId);
         return qestnrInfo;

--- a/EgovQuestionnaire/src/main/resources/templates/egovframework/com/uss/olp/qmc/qestnrInfoUpdate.html
+++ b/EgovQuestionnaire/src/main/resources/templates/egovframework/com/uss/olp/qmc/qestnrInfoUpdate.html
@@ -177,8 +177,8 @@
                 });
                 document.getElementById('qustnrTrget').innerHTML = cmmnDetailCodeHtml;
 
-                document.getElementById('startDate').value = response.result.qustnrBgnde;
-                document.getElementById('endDate').value = response.result.qustnrEndde;
+                document.getElementById('startDate').value = response.result.qustnrBgnde.replaceAll('/', '-');
+                document.getElementById('endDate').value = response.result.qustnrEndde.replaceAll('/', '-');
 
                 let qustnrTmplatId = response.result.qustnrTmplatId;
                 let qustnrTmplatList = response.qustnrTmplatList;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

설문 수정 화면에서 기존 시작일과 종료일이 표시되지 않는 문제를 수정했습니다.

상세 API가 반환하는 `yyyy/MM/dd` 형식의 날짜를 `input[type=date]`에서 사용할 수 있는 `yyyy-MM-dd` 형식으로 변환했습니다.

수정한 날짜를 저장할 때는 하이픈을 제거하여 기존 저장 형식인 `yyyyMMdd`를 유지하도록 변경했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

별도 JUnit 테스트는 추가하지 않았습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

시작일과 종료일 입력란이 비어 있는 화면

<img width="1600" height="1301" alt="설문 수정 기간 표시 전" src="https://github.com/user-attachments/assets/ad4f52f9-930a-4559-9e6d-7861c029b37b" />

### 수정 후

시작일과 종료일에 기존 설문 기간이 표시되는 화면

<img width="1600" height="1301" alt="설문 수정 기간 표시 후" src="https://github.com/user-attachments/assets/fc807977-fd6c-43b3-92ff-313cf0d13fea" />