### PR TITLE
fix(EgovBoard): 게시글 등록자 부분 검색 적용

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovBoardServiceImpl.java
@@ -148,7 +148,7 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
         } else if ("2".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
             where.and(bbs.nttCn.contains(searchKeyword));
         } else if ("3".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
-            where.and(userMaster.userNm.eq(searchKeyword));
+            where.and(userMaster.userNm.contains(searchKeyword));
         }
         where.and(bbs.useAt.eq("Y")).and(bbs.noticeAt.isNull());
 
@@ -570,7 +570,7 @@ public class EgovBoardServiceImpl extends EgovAbstractServiceImpl implements Ego
         } else if ("2".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
             where.and(bbs.nttCn.contains(searchKeyword));
         } else if ("3".equals(searchCondition) && searchKeyword != null && !searchKeyword.isEmpty()) {
-            where.and(userMaster.userNm.eq(searchKeyword));
+            where.and(userMaster.userNm.contains(searchKeyword));
         }
 
         if(listNm.equals("notice")){


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시글 목록에서 등록자 이름 전체를 입력해야만 검색되는 문제를 수정했습니다.

QueryDSL 전환 전 등록자 검색에서 사용하던 부분 일치 조건이 동등 비교 조건으로 변경되어 일부 이름으로 검색할 수 없었습니다.

일반 게시글과 공지글의 등록자 검색 조건을 `eq()`에서 `contains()`로 변경하여 기존 부분 검색 동작을 복원했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

별도 JUnit 테스트는 추가하지 않았습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

등록자 일부 이름으로 검색한 결과가 없는 화면

<img width="1600" height="390" alt="게시글 등록자 부분 검색 적용 전" src="https://github.com/user-attachments/assets/f591cab0-765a-42e4-8b06-f893389648e6" />

### 수정 후

등록자 일부 이름과 일치하는 게시글이 조회되는 화면

<img width="1600" height="509" alt="게시글 등록자 부분 검색 적용 후" src="https://github.com/user-attachments/assets/0aace2e8-dae7-4b85-9af9-11914bc7bef3" />