### PR TITLE
fix(EgovMain): 검색엔진 메뉴 영문 메시지 추가

### DIFF
--- a/EgovMain/src/main/resources/messages/egovframework/com/cmm/message_en.properties
+++ b/EgovMain/src/main/resources/messages/egovframework/com/cmm/message_en.properties
@@ -210,6 +210,7 @@ comCmm.left.3020=JFile File Download
 comCmm.left.3100=LDAP Org. Management
 comCmm.left.3110=LDAP Org. Graph
 comCmm.left.3200=WebMessenger
+comCmm.left.4000=Search Engine
 
 #EgovUnitContent(\ub85c\uadf8\uc778 \ud6c4 \ud398\uc774\uc9c0)#
 comCmm.unitContent.0=context-crypto.xml Be sure to change the algorithmKey and algorithmKeyHash default values \u200b\u200bin the file to something else.


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

영문 화면에서 검색엔진 메뉴가 `4000. 검색엔진`으로 표시되는 문제를 수정했습니다.

영문 메시지 파일에 누락된 `comCmm.left.4000` 메시지를 추가하여 `4000. Search Engine`으로 표시되도록 변경했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

메시지 파일 변경으로 별도 JUnit 테스트는 추가하지 않았습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

영문 메뉴에서 검색엔진 항목만 `4000. 검색엔진`으로 표시되는 화면

<img width="1280" height="1269" alt="검색엔진 메뉴 영문 메시지 추가 전" src="https://github.com/user-attachments/assets/b919d93f-4022-4787-9f5a-31e093d72ae5" />

### 수정 후

영문 메뉴의 검색엔진 항목이 `4000. Search Engine`으로 표시되는 화면

<img width="1280" height="1269" alt="검색엔진 메뉴 영문 메시지 추가 후" src="https://github.com/user-attachments/assets/860b84d9-40e8-4d6d-8cd1-1f199ebdeb78" />