### PR TITLE
fix(EgovBoard): 검색 입력 안내 영문 메시지 추가

### DIFF
--- a/EgovBoard/src/main/resources/messages/egovframework/com/message-common_en.properties
+++ b/EgovBoard/src/main/resources/messages/egovframework/com/message-common_en.properties
@@ -195,6 +195,9 @@ success.file.transfer=The file transfer is complete.
 errors.file.extension.none=There is no file extension.
 errors.file.extension.deny=Unacceptable file extension.
 
+#Search
+search.placeholder=\u0020Input Keyword
+
 #left#
 comCmm.uat.title=User Authentication/Directory Service
 comCmm.sec.title=Security


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시글 목록을 영어로 전환해도 검색어 입력 안내 일부가 한글로 표시되는 문제를 수정했습니다.

영문 공통 메시지 파일에 누락된 `search.placeholder`를 추가하여 검색어 입력 안내가 모두 영어로 표시되도록 변경했습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

메시지 파일 변경으로 별도 JUnit 테스트는 추가하지 않았습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

### 수정 전

영문 화면의 검색어 입력 안내가 `keyword을(를) 입력하세요.`로 표시되는 화면

<img width="1280" height="1269" alt="게시글 검색 입력 안내 영문 메시지 추가 전" src="https://github.com/user-attachments/assets/3082429d-d8dc-4ebc-89c0-69ffa2e062a2" />

### 수정 후

영문 화면의 검색어 입력 안내가 `keyword Input Keyword`로 표시되는 화면

<img width="1280" height="1269" alt="게시글 검색 입력 안내 영문 메시지 추가 후" src="https://github.com/user-attachments/assets/321c6c77-5b90-4281-a6e8-696631c15fbd" />