### PR TITLE
fix(EgovQuestionnaire): 설문 템플릿 수정 화면의 파일 선택 및 상태 표시 수정

### DIFF
--- a/EgovQuestionnaire/src/main/resources/templates/egovframework/com/uss/olp/qtm/qustnrTmplatUpdate.html
+++ b/EgovQuestionnaire/src/main/resources/templates/egovframework/com/uss/olp/qtm/qustnrTmplatUpdate.html
@@ -42,7 +42,7 @@
                             <div class="file-upload-btn-wrap">
                                 <input type="file" name="qustnrTmplatImageInfo" id="fileUpload" accept="image/*" hidden>
                                 <label for="fileUpload" class="krds-btn medium">
-                                    <button  th:text="#{input.cSelect}"><i class="svg-icon ico-upload"></i></button>
+                                    <button type="button" th:text="#{input.cSelect}"><i class="svg-icon ico-upload"></i></button>
                                 </label>
                             </div>
                         </div>
@@ -134,6 +134,7 @@
 
         function handleFile(files) {
             errorElement.textContent = '';
+            errorElement.style.display = 'none';
             fileUploadList.innerHTML = '';
             stateElement.value = '';
 
@@ -144,11 +145,13 @@
 
                 if (!validTypes.includes(file.type)) {
                     errorElement.textContent = '[(#{errors.file.extension})]';
+                    errorElement.style.display = 'block';
                     return;
                 }
 
                 if (file.size > maxSize) {
-                    errorElement.textContent = 'File size exceeds the limit of 50MB.';
+                    errorElement.textContent = 'File size exceeds the limit of 50KB.';
+                    errorElement.style.display = 'block';
                     return;
                 }
 
@@ -190,7 +193,9 @@
             } else {
                 document.getElementById('qustnrTmplatTy').value = response.result.qustnrTmplatTy;
                 document.getElementById('qustnrTmplatImageState').value = 'update';
-                document.getElementById('qustnrTmplatDc').textContent = response.result.qustnrTmplatDc;
+                const qustnrTmplatDc = document.getElementById('qustnrTmplatDc');
+                qustnrTmplatDc.value = response.result.qustnrTmplatDc;
+                document.getElementById('textCount').textContent = qustnrTmplatDc.value.length;
                 document.getElementById('qustnrTmplatPathNm').value = response.result.qustnrTmplatPathNm;
             }
         });


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

설문 템플릿 수정 화면에서 이미지 선택 버튼을 누르면 수정 폼이 제출되어 405 오류로 이동했습니다. 버튼을 파일 선택 용도로만 동작하도록 수정했습니다.

저장된 템플릿 설명을 불러올 때 글자 수가 `0/1000`으로 남던 문제를 수정했습니다. 이미지 형식이나 50KB 크기 제한에 걸린 경우 안내 문구가 보이도록 하고, 잘못 적힌 제한 단위도 바로잡았습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전 : 파일 선택 버튼을 누르면 405 오류로 이동하는 화면

![파일 선택 수정 전](https://github.com/user-attachments/assets/6ff44f34-3098-43c9-9bab-eb0ec6b04b1c)

수정 후 : 이미지 선택 후 파일명이 표시되고 수정 화면에 머무는 화면

![파일 선택 수정 후](https://github.com/user-attachments/assets/1c9bde3d-2468-461a-b362-cd05f374f76b)

수정 전 : 저장된 설명이 있어도 글자 수가 `0/1000`으로 표시되는 화면

![글자 수 수정 전](https://github.com/user-attachments/assets/dfc86e8e-7366-4770-b814-61513747ed56)

수정 후 : 저장된 설명의 글자 수가 `12/1000`으로 표시되는 화면

![글자 수 수정 후](https://github.com/user-attachments/assets/bf7097d8-f786-44e2-9309-0c7332153903)