### PR TITLE
fix(EgovBoard): 커뮤니티 수정 권한 검증 추가

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommunityServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/cmy/service/impl/EgovCommunityServiceImpl.java
@@ -207,12 +207,27 @@ public class EgovCommunityServiceImpl extends EgovAbstractServiceImpl implements
     @Transactional
     @Override
     public CommunityVO update(CommunityVO communityVO, Map<String, String> userInfo) {
+        String uniqId = userInfo != null ? userInfo.get("uniqId") : null;
+        if (ObjectUtils.isEmpty(uniqId)) {
+            throw new IllegalStateException("인증 정보가 없습니다.");
+        }
+
         return repository.findById(communityVO.getCmmntyId())
                 .map(result -> {
+                    CmmntyUserId memberId = new CmmntyUserId();
+                    memberId.setCmmntyId(communityVO.getCmmntyId());
+                    memberId.setEmplyrId(uniqId);
+                    boolean isManager = userRepository.findById(memberId)
+                            .filter(member -> "Y".equals(member.getUseAt()))
+                            .filter(member -> "Y".equals(member.getMngrAt()))
+                            .isPresent();
+                    if (!Objects.equals(uniqId, result.getFrstRegisterId()) && !isManager) {
+                        throw new IllegalStateException("수정 권한이 없습니다.");
+                    }
                     result.setCmmntyNm(communityVO.getCmmntyNm());
                     result.setCmmntyIntrcn(communityVO.getCmmntyIntrcn());
                     result.setLastUpdtPnttm(LocalDateTime.now());
-                    result.setLastUpdusrId(userInfo.get("uniqId"));
+                    result.setLastUpdusrId(uniqId);
                     return repository.save(result);
                 })
                 .map(EgovCommunityUtility::cmmntyEntityToVO).orElse(null);

--- a/EgovBoard/src/test/java/egovframework/com/cop/cmy/service/impl/EgovCommunityServiceImplTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/cmy/service/impl/EgovCommunityServiceImplTest.java
@@ -1,0 +1,59 @@
+package egovframework.com.cop.cmy.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import egovframework.com.cop.cmy.entity.Cmmnty;
+import egovframework.com.cop.cmy.repository.EgovCommunityRepository;
+import egovframework.com.cop.cmy.repository.EgovCommunityUserRepository;
+import egovframework.com.cop.cmy.service.CommunityVO;
+
+@ExtendWith(MockitoExtension.class)
+class EgovCommunityServiceImplTest {
+
+    @Mock
+    EgovCommunityRepository repository;
+
+    @Mock
+    EgovCommunityUserRepository userRepository;
+
+    @Mock
+    EgovIdGnrService idgenService;
+
+    @Mock
+    JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    EgovCommunityServiceImpl service;
+
+    @Test
+    void updateRejectsNonMember() {
+        CommunityVO request = new CommunityVO();
+        request.setCmmntyId("CMMNTY_TEST");
+        Cmmnty community = new Cmmnty();
+        community.setCmmntyId("CMMNTY_TEST");
+        community.setFrstRegisterId("OWNER");
+        when(repository.findById("CMMNTY_TEST")).thenReturn(Optional.of(community));
+        when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.update(request, Map.of("uniqId", "NON_MEMBER")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("수정 권한이 없습니다.");
+        verify(repository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

커뮤니티 비회원이 수정 API를 직접 호출해 다른 사용자의 커뮤니티 이름과 소개를 변경할 수 있었습니다.

수정 요청자의 인증 정보를 확인하고, 커뮤니티 생성자 또는 사용 중인 관리자에게만 수정을 허용했습니다. 권한이 없는 요청은 저장 전에 거부합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovCommunityServiceImplTest`에서 비회원의 수정 요청이 거부되고 저장이 호출되지 않는지 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전 : 비회원의 수정 요청으로 커뮤니티 이름과 소개가 변경된 화면

![커뮤니티 수정 권한 검증 전](https://github.com/user-attachments/assets/9e3d28a5-358e-4e58-a3e7-1a7d924c84ac)

수정 후 : 같은 비회원 요청에도 기존 이름과 소개가 유지된 화면

![커뮤니티 수정 권한 검증 후](https://github.com/user-attachments/assets/d601459c-2b4b-496c-81af-17eddd4d5eb4)

JUnit 테스트 결과

![JUnit 테스트 결과](https://github.com/user-attachments/assets/e78a4d3d-812a-432b-a4bd-1fb09ccedccc)