### PR TITLE
fix(EgovBoard): 게시글 수정 시 첨부파일 삭제 반영

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovFileServiceImpl.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/service/impl/EgovFileServiceImpl.java
@@ -121,15 +121,11 @@ public class EgovFileServiceImpl extends EgovAbstractServiceImpl implements Egov
 
     @Override
     public void deleteFileInfs(FileVO fileVO) {
-        if (ObjectUtils.isEmpty(fileVO.getDeleteFileSn()) || ObjectUtils.isEmpty(fileVO.getFileSn())) {
+        if (ObjectUtils.isEmpty(fileVO.getDeleteFileSn())) {
             return;
         }
 
         for (String num : fileVO.getDeleteFileSn()) {
-            // 토큰으로 검증된 단일 fileSn과 일치하는 값만 삭제한다.
-            if (!fileVO.getFileSn().equals(num)) {
-                continue;
-            }
             FileDetailId filedetailId = new FileDetailId();
             filedetailId.setAtchFileId(fileVO.getAtchFileId());
             filedetailId.setFileSn(num);

--- a/EgovBoard/src/main/resources/templates/egovframework/com/cop/brd/boardUpdate.html
+++ b/EgovBoard/src/main/resources/templates/egovframework/com/cop/brd/boardUpdate.html
@@ -275,7 +275,7 @@
             var name;
             var type;
             var size;
-            var sn = 1;
+            var sn = null;
             if(item instanceof File){
                 name= item.name;
                 type= item.type.split('/')[1];
@@ -333,7 +333,7 @@
         document.getElementById(`file_${index}`).remove();
         document.querySelector(".current").textContent = fileList.length;
         fileAppend(fileList);
-        if(index != null){
+        if(sn != null){
             deleteFileSn.push(sn);
         }
     }
@@ -452,21 +452,8 @@
             deleteFileSn: deleteFileSn
         };
 
-        // 기존 저장되어 있는 파일 삭제
-        if (deleteFileSn.length !== 0) {
-            $.ajax({
-                url: '/cop/brd/deleteFileInfs',
-                method: 'POST',
-                data: delData
-            }).done(function(result){
-                alert('성공')
-            }).fail(function(jqXHR, textStatus, errorThrown) {
-                console.error("Error details:", textStatus, errorThrown);
-                alert('[(#{fail.common.msg})]');
-            });
-        }
-
         if (confirm('[(#{common.update.msg})]')) {
+            const updateBoard = function() {
             $('#nttSjError, #nttCnError').text('');
             $('#nttSjError, #nttSjError').css('display','none');
             $.ajax({
@@ -493,6 +480,20 @@
                 var msg = (raw && String(raw).trim()) ? String(raw).trim() : '[(#{fail.common.update})]';
                 alert(msg);
             });
+            };
+
+            if (deleteFileSn.length !== 0) {
+                $.ajax({
+                    url: '/cop/brd/deleteFileInfs',
+                    method: 'POST',
+                    data: delData
+                }).done(updateBoard).fail(function(jqXHR, textStatus, errorThrown) {
+                    console.error("Error details:", textStatus, errorThrown);
+                    alert('[(#{fail.common.msg})]');
+                });
+            } else {
+                updateBoard();
+            }
         }
     }
 </script>

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovFileServiceImplTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/service/impl/EgovFileServiceImplTest.java
@@ -1,0 +1,55 @@
+package egovframework.com.cop.brd.service.impl;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.egovframe.rte.fdl.idgnr.EgovIdGnrService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import egovframework.com.cop.brd.entity.FileDetailId;
+import egovframework.com.cop.brd.repository.EgovFileDetailRepository;
+import egovframework.com.cop.brd.repository.EgovFileRepository;
+import egovframework.com.cop.brd.service.FileVO;
+
+@ExtendWith(MockitoExtension.class)
+class EgovFileServiceImplTest {
+
+    @Mock
+    EgovFileRepository fileRepository;
+
+    @Mock
+    EgovFileDetailRepository fileDetailRepository;
+
+    @Mock
+    EgovIdGnrService idGnrService;
+
+    @InjectMocks
+    EgovFileServiceImpl service;
+
+    @Test
+    void deleteFileInfsDeletesValidatedFileNumbers() {
+        FileVO request = new FileVO();
+        request.setAtchFileId("FILE_TEST");
+        request.setDeleteFileSn(new String[] {"0", "2"});
+        when(fileDetailRepository.findAllByFileDetailId_AtchFileId("FILE_TEST"))
+                .thenReturn(Collections.emptyList());
+
+        service.deleteFileInfs(request);
+
+        verify(fileDetailRepository).deleteById(fileId("FILE_TEST", "0"));
+        verify(fileDetailRepository).deleteById(fileId("FILE_TEST", "2"));
+    }
+
+    private FileDetailId fileId(String attachmentId, String fileNumber) {
+        FileDetailId id = new FileDetailId();
+        id.setAtchFileId(attachmentId);
+        id.setFileSn(fileNumber);
+        return id;
+    }
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시글 수정 화면에서 기존 첨부파일을 제거하고 저장해도 파일이 그대로 남는 문제를 수정했습니다.

삭제할 기존 파일의 번호를 전달하도록 화면 로직을 정리하고, 서비스가 전달된 파일 번호 목록을 처리하도록 변경했습니다. 저장 확인창에서 확인을 누른 뒤 파일 삭제가 끝나면 게시글 수정을 진행합니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`EgovFileServiceImplTest`에서 전달된 파일 번호들이 삭제 처리되는지 확인했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

수정 전 : 파일 하나를 제거하고 저장해도 첨부파일 2개가 남은 화면

![게시글 첨부파일 삭제 수정 전](https://github.com/user-attachments/assets/e6d6a815-27b7-4ce8-9b0c-26eae366b841)

수정 후 : 선택한 파일만 삭제되어 첨부파일 1개가 남은 화면

![게시글 첨부파일 삭제 수정 후](https://github.com/user-attachments/assets/add21ce9-9728-480a-917b-552b7e239011)

JUnit 테스트 결과

![JUnit 테스트 결과](https://github.com/user-attachments/assets/0d0b9e53-aa19-4440-88a3-ad7ad44fdd51)